### PR TITLE
Reorder the map_extent for Cesium version of MapView

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,12 @@ Primary changes in this Pull Request:
 
 Please review the checklist before submitting the Pull Request:
 
-- [] Pull request has a meaning full name (not just the commit message from of your last commit)
-- [] Code has been linted using flake8
-- [] All methods have accurate Google-Style Docstrings
-- [] 100% test coverage for new content
-- [] Tests for each common use case (please don't write one test that covers all use cases)
-- [] Bonus: Use TypeHints
+- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
+- [ ] Code has been linted using flake8
+- [ ] All methods have accurate Google-Style Docstrings
+- [ ] 100% test coverage for new content
+- [ ] Tests for each common use case (please don't write one test that covers all use cases)
+- [ ] Bonus: Use TypeHints
 
 Explain deviations from original design if applicable:
 

--- a/tethysext/atcore/public/map_view/atcore_cesium_map_view.js
+++ b/tethysext/atcore/public/map_view/atcore_cesium_map_view.js
@@ -119,6 +119,8 @@ var ATCORE_MAP_VIEW = (function() {
         var $map_attributes = $('#atcore-map-attributes');
         m_layer_groups = $map_attributes.data('layer-groups');
         m_extent = $map_attributes.data('map-extent');
+        // Remap extent to order cesium expects
+        m_extent = [m_extent[2], m_extent[3], m_extent[0], m_extent[1]];
         m_workspace = $map_attributes.data('workspace');
         m_enable_properties_popup = $map_attributes.data('enable-properties-popup');
         m_map_type = $map_attributes.data('map-type');
@@ -146,12 +148,10 @@ var ATCORE_MAP_VIEW = (function() {
     };
 
     setup_map = function() {
-        // Change Extent Button from "E" to Extent Symbol
-        let $extent_button = $('button[title="Fit to extent"]');
-        $extent_button.html('<span class="glyphicon glyphicon-home"></span>')
-
-        Cesium.Camera.DEFAULT_VIEW_RECTANGLE = Cesium.Rectangle.fromDegrees(m_extent[0], m_extent[1],
-                                                                          m_extent[2], m_extent[3]);
+        // Set "Home" extent
+        Cesium.Camera.DEFAULT_VIEW_RECTANGLE = Cesium.Rectangle.fromDegrees(
+            m_extent[0], m_extent[1], m_extent[2], m_extent[3]
+        );
         Cesium.Camera.DEFAULT_VIEW_FACTOR = 0;
 
         // Get handle on map

--- a/tethysext/atcore/services/map_manager.py
+++ b/tethysext/atcore/services/map_manager.py
@@ -186,7 +186,7 @@ class MapManagerBase(object):
     def build_wms_layer(self, endpoint, layer_name, layer_title, layer_variable, viewparams=None, env=None,
                         visible=True, tiled=True, selectable=False, plottable=False, has_action=False, extent=None,
                         public=True, geometry_attribute='geometry', layer_id='', excluded_properties=None,
-                        popup_title=None, color_ramp_division_kwargs=dict):
+                        popup_title=None, color_ramp_division_kwargs=None):
         """
         Build an WMS MVLayer object with supplied arguments.
         Args:


### PR DESCRIPTION
Primary changes in this Pull Request:

- Reorder the map_extent in the cesium map view 
- Did this in the JavaScript so the same extent can be used interchangeably between OpenLayers and Cesium MapView renderers.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

N/A