### PR TITLE
- Manage resource only shows associated resource class.

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -286,7 +286,8 @@ class ManageResources(AppUsersViewMixin):
         Returns:
             list<Resources>: the list of resources to render on the manage_resources page.
         """
-        return request_app_user.get_resources(session, request)
+        of_type = self.get_resource_model()
+        return request_app_user.get_resources(session, request, of_type=of_type)
 
     def perform_custom_delete_operations(self, request, resource):
         """

--- a/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
@@ -402,17 +402,18 @@ class ManageResourcesTests(SqlAlchemyTestCase):
                 'href': mock_reverse(),
             }, ret)
 
-    def test_get_resources(self):
+    @mock.patch('tethysext.atcore.controllers.app_users.mixins.AppUsersViewMixin.get_resource_model')
+    def test_get_resources(self, mock_get_resource_model):
         mock_request = self.request_factory.get('/foo/bar/')
         mock_session = mock.MagicMock()
         mock_request_app_user = mock.MagicMock()
-
+        mock_get_resource_model.return_value = 'resource_type'
         # Call the method
         manage_resources = ManageResources()
         manage_resources.get_resources(mock_session, mock_request, mock_request_app_user)
 
         # Test the results
-        mock_request_app_user.get_resources.assert_called_with(mock_session, mock_request)
+        mock_request_app_user.get_resources.assert_called_with(mock_session, mock_request, of_type='resource_type')
 
     @mock.patch('tethysext.atcore.controllers.app_users.manage_resources.has_permission')
     def test_can_edit_resource(self, mock_has_permission):


### PR DESCRIPTION

- Add resource type to app_user get_resources method to return the correct resource list.
