### PR TITLE
Pass managed session to the get_summmary_tab_info call.

### DIFF
--- a/tethysext/atcore/controllers/resources/tabs/summary_tab.py
+++ b/tethysext/atcore/controllers/resources/tabs/summary_tab.py
@@ -44,7 +44,7 @@ class ResourceSummaryTab(ResourceTab):
         """
         return None
 
-    def get_summary_tab_info(self, request, resource, *args, **kwargs):
+    def get_summary_tab_info(self, request, session, resource, *args, **kwargs):
         """
         Get the summary tab info
 
@@ -74,7 +74,7 @@ class ResourceSummaryTab(ResourceTab):
                                                     'Date Created': resource.date_created})
 
         # Add general_summary_tab_info as first item in first columns
-        summary_tab_info = self.get_summary_tab_info(request, resource)
+        summary_tab_info = self.get_summary_tab_info(request, session, resource)
         if len(summary_tab_info) == 0:
             summary_tab_info = [[general_summary_tab_info]]
         else:

--- a/tethysext/atcore/tests/integrated_tests/controllers/resources/tabs/summary_tab_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resources/tabs/summary_tab_tests.py
@@ -137,7 +137,7 @@ class ResourceSummaryTabTests(SqlAlchemyTestCase):
         """Test default implementation of get_summary_tab_info."""
         instance = ResourceSummaryTab()
         request = self.request_factory.get('/foo/12345/bar/summary/')
-        ret = instance.get_summary_tab_info(request, self.resource)
+        ret = instance.get_summary_tab_info(request, self.session, self.resource)
         self.assertListEqual([], ret)
 
     @mock.patch('tethysext.atcore.controllers.resources.tabs.summary_tab.render')


### PR DESCRIPTION
Primary changes in this Pull Request:

- Pass the managed session object to the get_summary_tab_info call.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

