### PR TITLE
Fix Resource Status Page to Only Show Jobs for One Resource

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ rm -f .coverage
 echo "Running Unit Tests..."
 coverage run -a --rcfile=coverage.ini -m unittest tethysext.atcore.tests.unit_tests
 echo "Running Intermediate Tests..."
-coverage run -a --rcfile=coverage.ini $1 test -v 1 tethysext.atcore.tests.integrated_tests
+coverage run -a --rcfile=coverage.ini "$1" test -v 1 tethysext.atcore.tests.integrated_tests
 echo "Combined Coverage Report..."
 coverage report -m --rcfile=coverage.ini
 echo "Linting..."

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,9 @@ if [ ! -f "$1" ]; then
 fi
 rm -f .coverage
 echo "Running Unit Tests..."
-coverage run -a --rcfile=coverage.ini -m unittest -v tethysext.atcore.tests.unit_tests
+coverage run -a --rcfile=coverage.ini -m unittest tethysext.atcore.tests.unit_tests
 echo "Running Intermediate Tests..."
-coverage run -a --rcfile=coverage.ini $1 test -v 2 tethysext.atcore.tests.integrated_tests
+coverage run -a --rcfile=coverage.ini $1 test -v 1 tethysext.atcore.tests.integrated_tests
 echo "Combined Coverage Report..."
 coverage report -m --rcfile=coverage.ini
 echo "Linting..."

--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -227,7 +227,7 @@ class ManageResources(AppUsersViewMixin):
         """
         Get the URL for the Resource Working button.
         """
-        return reverse(f'{self._app.namespace}:{resource.SLUG}_resource_status')
+        return reverse(f'{self._app.namespace}:{resource.SLUG}_resource_status') + f'?r={resource.id}'
 
     def get_launch_url(self, request, resource):
         """

--- a/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
@@ -358,6 +358,7 @@ class ManageResourcesTests(SqlAlchemyTestCase):
     @mock.patch('tethysext.atcore.controllers.app_users.manage_resources.reverse')
     def test_get_resource_action_working_status(self, mock_reverse):
         mock_resource = mock.MagicMock()
+        mock_resource.id = 12345
         mock_resource.SLUG = "resources"
         mock_resource.WORKING_STATUSES = StatusMixin.WORKING_STATUSES
         mock_resource.get_status.return_value = 'Processing'
@@ -376,7 +377,7 @@ class ManageResourcesTests(SqlAlchemyTestCase):
             {
                 'action': ManageResources.ACTION_PROCESSING,
                 'title': 'Processing',
-                'href': mock_reverse()
+                'href': 'processing_url?r=12345'
             }, ret)
 
     @mock.patch('tethysext.atcore.controllers.app_users.manage_resources.reverse')

--- a/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_users_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_users_tests.py
@@ -7,6 +7,7 @@
 ********************************************************************************
 """
 import json
+import sys
 from unittest import mock
 from django.http import HttpRequest
 from django.contrib.auth.models import User
@@ -204,7 +205,10 @@ class ManageUsersTests(SqlAlchemyTestCase):
 
         response_dict = json.loads(response._container[0].decode('utf-8'))
         self.assertFalse(response_dict['success'])
-        self.assertEqual("Exception('Some exception message')", response_dict['error'])
+        if sys.version_info.minor <= 6:
+            self.assertEqual("Exception('Some exception message',)", response_dict['error'])
+        else:
+            self.assertEqual("Exception('Some exception message')", response_dict['error'])
 
     @mock.patch('tethysext.atcore.controllers.app_users.mixins.AppUsersViewMixin.get_permissions_manager')
     def test_delete_remove(self, _):
@@ -229,7 +233,10 @@ class ManageUsersTests(SqlAlchemyTestCase):
 
         response_dict = json.loads(response._container[0].decode('utf-8'))
         self.assertFalse(response_dict['success'])
-        self.assertEqual("Exception('Some exception message')", response_dict['error'])
+        if sys.version_info.minor <= 6:
+            self.assertEqual("Exception('Some exception message',)", response_dict['error'])
+        else:
+            self.assertEqual("Exception('Some exception message')", response_dict['error'])
 
     def test_delete_unknown_action(self):
         self.request.GET = {'action': 'swim'}


### PR DESCRIPTION
Primary changes in this Pull Request:

- Added the `resource_id` parameter (`r`) to the link from the manage  resource page to status page
- This filters the list of jobs to only those that have the `resource_id` in their `extended_properties`.
- Won't show all of the jobs that have ever run now
- Bonus: Fixed some tests that were failing in Python 3.6 and made test.sh less verbose.

![image](https://user-images.githubusercontent.com/5123221/104781716-385bdd00-5740-11eb-8b7a-1ab9e5075e2b.png)


Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

