### PR TITLE
Add ability to add arbitrary attributes to Organizations

### DIFF
--- a/tethysext/atcore/models/app_users/organization.py
+++ b/tethysext/atcore/models/app_users/organization.py
@@ -4,13 +4,14 @@ from sqlalchemy import Column, Boolean, String, ForeignKey, DateTime, func
 from sqlalchemy.orm import relationship, backref, validates
 from tethysext.atcore.models.types.guid import GUID
 from tethysext.atcore.services.app_users.licenses import Licenses
+from tethysext.atcore.mixins import AttributesMixin
 from .associations import organization_resource_association, user_organization_association
 from .base import AppUsersBase
 
 __all__ = ['Organization']
 
 
-class Organization(AppUsersBase):
+class Organization(AppUsersBase, AttributesMixin):
     """
     Definition for organizations table.
     """
@@ -31,6 +32,7 @@ class Organization(AppUsersBase):
     license_expires = Column(DateTime)
     active = Column(Boolean, default=True)
     archived = Column(Boolean, default=False)
+    _attributes = Column(String)
 
     # Relationships
     resources = relationship('Resource',

--- a/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
@@ -245,7 +245,7 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
     def test_prepare(self):
         self.app.get_scheduler = mock.MagicMock(return_value=self.scheduler)
         manager = Manager(self.session, self.model_db, self.step, self.user, self.working_directory, self.app,
-                          self.scheduler_name, jobs=self.jobs, input_files=[self.key_path])
+                          self.scheduler_name, jobs=self.jobs, input_files=[str(self.key_path)])
 
         id = manager.prepare()
 


### PR DESCRIPTION
Primary changes in this Pull Request:

- Add `_attributes` column to Organizations model
- Add Attributes mixin to Organizations

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [x] Bonus: Use TypeHints

Explain deviations from original design if applicable:

