### PR TITLE
Agwa culvert workflow validation update and post-processing fixes

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
@@ -479,7 +479,8 @@ class SpatialInputMWV(MapWorkflowView):
                             # Polygon and Extent feature
                             cur_x.append(val[0])
                             cur_y.append(val[1])
-            min_sort_vals.append((min(cur_x), min(cur_y), idx))
+            cur_val = (min(cur_x), min(cur_y), idx) if cur_x and cur_y else (None, None, idx)
+            min_sort_vals.append(cur_val)
         # Sort the min coordinates, and then store the features in that order
         s_features = []
         sorted_values = sorted(min_sort_vals)

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
@@ -477,7 +477,7 @@ class SpatialInputMWV(MapWorkflowView):
 
             # Generate ID if not given
             if 'id' not in feature['properties']:
-                feature['properties']['id'] = str(uuid.uuid4())
+                feature['properties']['id'] = 'drawing_layer.' + str(uuid.uuid4())
 
             post_processed_geojson['features'].append(processed_feature)
 

--- a/tethysext/atcore/forms/widgets/param_widgets.py
+++ b/tethysext/atcore/forms/widgets/param_widgets.py
@@ -181,7 +181,7 @@ def generate_django_form(parameterized_obj, form_field_prefix=None, read_only=Fa
         if form_field_prefix is not None:
             p_name = form_field_prefix + p_name
 
-        # Get appropriate Django field/widget based on param type           
+        # Get appropriate Django field/widget based on param type
         form_class.base_fields[p_name] = widget_map[type(p)](parameterized_obj, p, p.name)
 
         # Set label with param label if set, otherwise derive from parameter name

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
@@ -145,7 +145,7 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
             except TypeError:
                 validation_errors.append(f'{attribute_title} must be a number.')
                 continue
-            
+
             # Convert "on" value to boolean for Boolean fields
             if isinstance(defined_attribute, param.Boolean):
                 val = val in ('on', 'checked')

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
@@ -121,7 +121,6 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
             attribute_title = (
                 defined_attribute.label if defined_attribute.label else attribute_name.replace("_", " ").title()
             )
-            # attribute_title = attribute_name.replace("_", " ").title()
 
             # Skip attributes that are not given, raising a validation error if it is required
             if attribute_name not in attributes:

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
@@ -123,7 +123,7 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
             # Skip attributes that are not given, raising a validation error if it is required
             if attribute_name not in attributes:
                 if value_required:
-                    validation_errors.append(f'{attribute_title} is required.')
+                    validation_errors.append(f'{defined_attribute.label} is required.')
                 continue
 
             # Get the value
@@ -133,7 +133,7 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
             val = None if value in null_equivalents else value
 
             if val is None and value_required:
-                validation_errors.append(f'{attribute_title} is required.')
+                validation_errors.append(f'{defined_attribute.label} is required.')
                 continue
 
             # Cast values to numbers if definition is a number field

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_input_rws.py
@@ -118,12 +118,15 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
         for attribute_name, defined_attribute in all_defined_attributes.items():
             # Validate parameters that are "Required" but have no value
             value_required = not defined_attribute.allow_None
-            attribute_title = attribute_name.replace("_", " ").title()
+            attribute_title = (
+                defined_attribute.label if defined_attribute.label else attribute_name.replace("_", " ").title()
+            )
+            # attribute_title = attribute_name.replace("_", " ").title()
 
             # Skip attributes that are not given, raising a validation error if it is required
             if attribute_name not in attributes:
                 if value_required:
-                    validation_errors.append(f'{defined_attribute.label} is required.')
+                    validation_errors.append(f'{attribute_title} is required.')
                 continue
 
             # Get the value
@@ -133,7 +136,7 @@ class SpatialInputRWS(SpatialResourceWorkflowStep):
             val = None if value in null_equivalents else value
 
             if val is None and value_required:
-                validation_errors.append(f'{defined_attribute.label} is required.')
+                validation_errors.append(f'{attribute_title} is required.')
                 continue
 
             # Cast values to numbers if definition is a number field

--- a/tethysext/atcore/public/map_view/atcore_map_view.js
+++ b/tethysext/atcore/public/map_view/atcore_map_view.js
@@ -1237,15 +1237,17 @@ var ATCORE_MAP_VIEW = (function() {
     };
 
     generate_properties_table_title = function(feature, layer) {
-        let title = '';
+        let title = 'Properties';
 
         // Get custom title from layer data properties
-        if (layer.hasOwnProperty('tethys_data') && layer.tethys_data.hasOwnProperty('popup_title')) {
-            title = layer.tethys_data.popup_title;
-        }
-        // Or use the legend title as a fallback
-        else {
-            title = layer.tethys_legend_title;
+        if (layer) {
+            if (layer.hasOwnProperty('tethys_data') && layer.tethys_data.hasOwnProperty('popup_title')) {
+                title = layer.tethys_data.popup_title;
+            }
+            // Or use the legend title as a fallback
+            else {
+                title = layer.tethys_legend_title;
+            }
         }
 
         let title_markup = '<h6 class="properites-title">' + title + '</h6>';

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -613,13 +613,13 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
         self.assertEqual(geojson['features'][2]['geometry']['type'], ret['features'][0]['geometry']['type'])
         self.assertEqual(geojson['features'][2]['geometry']['coordinates'],
                          ret['features'][0]['geometry']['coordinates'])
-        # Make sure the LineString (second feature in geojson) comes second in the return value
-        self.assertEqual(geojson['features'][1]['geometry']['type'], ret['features'][1]['geometry']['type'])
-        self.assertEqual(geojson['features'][1]['geometry']['coordinates'],
-                         ret['features'][1]['geometry']['coordinates'])
-        # Make sure the Polygon (first feature in geojson) comes last in the return value
-        self.assertEqual(geojson['features'][0]['geometry']['type'], ret['features'][2]['geometry']['type'])
+        # Make sure the LineString (first feature in geojson) comes second in the return value
+        self.assertEqual(geojson['features'][0]['geometry']['type'], ret['features'][1]['geometry']['type'])
         self.assertEqual(geojson['features'][0]['geometry']['coordinates'],
+                         ret['features'][1]['geometry']['coordinates'])
+        # Make sure the Polygon (second feature in geojson) comes last in the return value
+        self.assertEqual(geojson['features'][1]['geometry']['type'], ret['features'][2]['geometry']['type'])
+        self.assertEqual(geojson['features'][1]['geometry']['coordinates'],
                          ret['features'][2]['geometry']['coordinates'])
         self.assertIn('properties', ret['features'][0])
         self.assertIn('properties', ret['features'][1])

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -562,7 +562,7 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
         geojson = {
             'features': [
                 {'geometry': {'coordinates': [], 'type': 'some_type'}, 'properties': {}},
-                {'geometry': {'coordinates': [], 'type': ''}}
+                {'geometry': {'coordinates': [], 'type': 'some_type'}, 'properties': {}}
             ]
         }
 

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -586,11 +586,11 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
             'features': [
                 {'geometry': {'coordinates': [[-86.713342, 33.500775], [-86.704177, 33.507294]], 'type': 'LineString'},
                  'properties': {}},
-                {'geometry': {'coordinates': [[-86.655385, 33.532015],
-                                              [-86.655385, 33.542351],
-                                              [-86.629775, 33.542351],
-                                              [-86.629775, 33.532015],
-                                              [-86.655385, 33.532015]], 'type': 'Polygon'},
+                {'geometry': {'coordinates': [[[-86.655385, 33.532015],
+                                               [-86.655385, 33.542351],
+                                               [-86.629775, 33.542351],
+                                               [-86.629775, 33.532015],
+                                               [-86.655385, 33.532015]]], 'type': 'Polygon'},
                  'properties': {}},
                 {'geometry': {'coordinates': [-87.718464, 33.49583], 'type': 'Point'}, 'properties': {}},
             ]

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -579,3 +579,48 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
         self.assertEqual(geojson['features'][0]['geometry']['coordinates'],
                          ret['features'][0]['geometry']['coordinates'])
         self.assertIn('properties', ret['features'][0])
+
+    def test_post_process_geojson_sorting(self):
+        # When sorted, the Point type should be first, then LineString, then Polygon
+        geojson = {
+            'features': [
+                {'geometry': {'coordinates': [[-86.713342, 33.500775], [-86.704177, 33.507294]], 'type': 'LineString'},
+                 'properties': {}},
+                {'geometry': {'coordinates': [[-86.655385, 33.532015],
+                                              [-86.655385, 33.542351],
+                                              [-86.629775, 33.542351],
+                                              [-86.629775, 33.532015],
+                                              [-86.655385, 33.532015]], 'type': 'Polygon'},
+                 'properties': {}},
+                {'geometry': {'coordinates': [-87.718464, 33.49583], 'type': 'Point'}, 'properties': {}},
+            ]
+        }
+
+        ret = SpatialInputMWV().post_process_geojson(geojson)
+
+        self.assertIn('type', ret)
+        self.assertIn('crs', ret)
+        self.assertIn('type', ret['crs'])
+        self.assertIn('properties', ret['crs'])
+        self.assertIn('features', ret)
+        self.assertIn('type', ret['features'][0])
+        self.assertIn('geometry', ret['features'][0])
+        self.assertIn('type', ret['features'][1])
+        self.assertIn('geometry', ret['features'][1])
+        self.assertIn('type', ret['features'][2])
+        self.assertIn('geometry', ret['features'][2])
+        # Make sure the Point (last feature in geojson) comes first in the return value
+        self.assertEqual(geojson['features'][2]['geometry']['type'], ret['features'][0]['geometry']['type'])
+        self.assertEqual(geojson['features'][2]['geometry']['coordinates'],
+                         ret['features'][0]['geometry']['coordinates'])
+        # Make sure the LineString (second feature in geojson) comes second in the return value
+        self.assertEqual(geojson['features'][1]['geometry']['type'], ret['features'][1]['geometry']['type'])
+        self.assertEqual(geojson['features'][1]['geometry']['coordinates'],
+                         ret['features'][1]['geometry']['coordinates'])
+        # Make sure the Polygon (first feature in geojson) comes last in the return value
+        self.assertEqual(geojson['features'][0]['geometry']['type'], ret['features'][2]['geometry']['type'])
+        self.assertEqual(geojson['features'][0]['geometry']['coordinates'],
+                         ret['features'][2]['geometry']['coordinates'])
+        self.assertIn('properties', ret['features'][0])
+        self.assertIn('properties', ret['features'][1])
+        self.assertIn('properties', ret['features'][2])

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -562,7 +562,7 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
         geojson = {
             'features': [
                 {'geometry': {'coordinates': [], 'type': 'some_type'}, 'properties': {}},
-                {'geometry': {'coordinates': []}}
+                {'geometry': {'coordinates': [], 'type': ''}}
             ]
         }
 


### PR DESCRIPTION
Primary changes in this Pull Request:
Changed workflow validation errors to use attribute labels instead of titles.  Fixed post-processing of geojson in SpatialInputMWV, to include the drawing_layer name and sorting more feature types than just points.
- 

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [x] Bonus: Use TypeHints

Explain deviations from original design if applicable:

