### PR TITLE
Refactor HTCondor workflow manager to allow specifying jobs with a callback function

### DIFF
--- a/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
+++ b/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
@@ -6,6 +6,7 @@
 * Copyright: (c) Aquaveo 2019
 ********************************************************************************
 """
+import inspect
 import logging
 import os
 from tethys_sdk.jobs import CondorWorkflowJobNode
@@ -39,9 +40,8 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
             jobs(list<CondorWorkflowJobNode or dict>): List of CondorWorkflowJobNodes to run.
             input_files(list<str>): List of paths to files to sends as inputs to every job. Optional.
         """  # noqa: E501
-        if not jobs or not all(isinstance(x, (dict, CondorWorkflowJobNode)) for x in jobs):
-            raise ValueError('Argument "jobs" is not defined or empty. Must provide at least one CondorWorkflowJobNode '
-                             'or equivalent dictionary.')
+        self.jobs_are_function = inspect.isfunction(jobs)
+        self.validate_jobs(jobs)
 
         # DB url for database containing the resource
         self.resource_db_url = str(session.get_bind().url)
@@ -78,7 +78,7 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
 
         # Job Definition Variables
         self.jobs = jobs
-        self.jobs_are_dicts = isinstance(jobs[0], dict)
+        self.session = session
         self.user = user
         self.working_directory = working_directory
         self.app = app
@@ -186,9 +186,13 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
         # Save the workflow
         self.workflow.save()
 
-        # Preprocess jobs if they are dicts
-        if self.jobs_are_dicts:
-            self.jobs = self._build_job_nodes(self.jobs)
+        # Preprocess jobs if they are dicts or a callback function
+        cur_jobs = self.jobs(self) if self.jobs_are_function else self.jobs
+        self.validate_jobs(cur_jobs)  # Validate again (needed if self.jobs was a callback function)
+        if isinstance(cur_jobs[0], dict):
+            # Jobs are dicts
+            cur_jobs = self._build_job_nodes(cur_jobs)
+        self.jobs = cur_jobs
 
         # Add file names as args
         input_file_names = []
@@ -310,3 +314,15 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
         # Execute
         self.workflow.execute()
         return str(self.workflow.id)
+
+    def validate_jobs(self, jobs):
+        """
+        Validates that the jobs are defined (not empty) and are a CondorWorkflowJobNode or equivalent dicaiontry.
+
+        Args:
+            jobs(list<CondorWorkflowJobNode or dict>): List of CondorWorkflowJobNodes to run.
+        """
+        if not inspect.isfunction(jobs):
+            if not jobs or not all(isinstance(x, (dict, CondorWorkflowJobNode)) for x in jobs):
+                raise ValueError('Argument "jobs" is not defined or empty. Must provide at least one '
+                                 'CondorWorkflowJobNode or equivalent dictionary.')

--- a/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
+++ b/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
@@ -328,5 +328,5 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
             not jobs or
             (not inspect.isfunction(jobs) and not all(isinstance(x, (dict, CondorWorkflowJobNode)) for x in jobs))
         ):
-            raise ValueError('"jobs" is not defined or empty. Must provide at least one '
+            raise ValueError('Given "jobs" is not defined or empty. Must provide at least one '
                              'CondorWorkflowJobNode or equivalent dictionary.')

--- a/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
@@ -228,7 +228,7 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
                     self.scheduler_name, jobs=None)
             self.assertTrue(False)  # This line should not be reached
         except ValueError as e:
-            self.assertEqual('"jobs" is not defined or empty. Must provide at least one CondorWorkflowJobNode '
+            self.assertEqual('Given "jobs" is not defined or empty. Must provide at least one CondorWorkflowJobNode '
                              'or equivalent dictionary.', str(e))
 
     def test_workspace_no_path(self):

--- a/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
@@ -150,7 +150,7 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
         self.assertEqual(str(self.step.id), manager.resource_workflow_step_id)
         self.assertEqual(self.step.name, manager.resource_workflow_step_name)
         self.assertEqual(self.jobs, manager.jobs)
-        self.assertTrue(manager.jobs_are_dicts)
+        self.assertFalse(manager.jobs_are_function)
         self.assertEqual(self.user, manager.user)
         self.assertEqual(self.working_directory, manager.working_directory)
         self.assertEqual(self.app, manager.app)
@@ -200,7 +200,7 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
         self.assertEqual(str(self.step.id), manager.resource_workflow_step_id)
         self.assertEqual(self.step.name, manager.resource_workflow_step_name)
         self.assertEqual(self.jobs, manager.jobs)
-        self.assertTrue(manager.jobs_are_dicts)
+        self.assertFalse(manager.jobs_are_function)
         self.assertEqual(self.user, manager.user)
         self.assertEqual(self.working_directory, manager.working_directory)
         self.assertEqual(self.app, manager.app)
@@ -327,3 +327,80 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
         id = manager.run_job()
 
         self.assertEqual(str(2), id)
+
+    def test_run_prepare_with_callback_function(self):
+        def callback_func(manager):
+            return self.jobs
+
+        self.app.get_scheduler = mock.MagicMock(return_value=self.scheduler)
+        manager = Manager(self.session, self.model_db, self.step, self.user, self.working_directory, self.app,
+                          self.scheduler_name, jobs=callback_func, input_files=[str(self.key_path)])
+
+        id = manager.prepare()
+
+        # Job 1
+        self.assertEqual(self.jobs[0]['name'], manager.jobs[0].name)
+        self.assertEqual(3, manager.jobs[0].workflow.id)
+        self.assertEqual(3, manager.jobs[0].workflow_id)
+        self.assertEqual(self.jobs[0]['name'], manager.jobs[0]._attributes['job_name'])
+        self.assertEqual('vanilla', manager.jobs[0]._attributes['universe'])
+        self.assertEqual('run_base_scenario.py', manager.jobs[0]._attributes['executable'])
+        expected_args = f'{self.session.get_bind().url} {self.model_db.db_url} {self.workflow.resource.id} ' \
+            f'{self.workflow.id} {self.step.id}   {manager._get_class_path(self.workflow.resource)} ' \
+            f'{manager._get_class_path(self.workflow)} testkey'
+        self.assertEqual(expected_args, manager.jobs[0]._attributes['arguments'])
+        self.assertEqual(', ../testkey', manager.jobs[0]._attributes['transfer_input_files'])
+        self.assertEqual('gssha_files, base_ohl_series.json', manager.jobs[0]._attributes['transfer_output_files'])
+
+        # Job 2
+        self.assertEqual(self.jobs[1]['name'], manager.jobs[1].name)
+        self.assertEqual(3, manager.jobs[1].workflow.id)
+        self.assertEqual(3, manager.jobs[1].workflow_id)
+        self.assertEqual(self.jobs[1]['name'], manager.jobs[1]._attributes['job_name'])
+        self.assertEqual('vanilla', manager.jobs[1]._attributes['universe'])
+        self.assertEqual('run_detention_basin_scenario.py', manager.jobs[1]._attributes['executable'])
+        self.assertEqual(expected_args, manager.jobs[1]._attributes['arguments'])
+        self.assertEqual(', ../testkey', manager.jobs[1]._attributes['transfer_input_files'])
+        self.assertEqual('gssha_files, detention_basin_ohl_series.json',
+                         manager.jobs[1]._attributes['transfer_output_files'])
+
+        # Job 3
+        self.assertEqual(self.jobs[2]['name'], manager.jobs[2].name)
+        self.assertEqual(3, manager.jobs[2].workflow.id)
+        self.assertEqual(3, manager.jobs[2].workflow_id)
+        self.assertEqual(self.jobs[2]['name'], manager.jobs[2]._attributes['job_name'])
+        self.assertEqual('vanilla', manager.jobs[2]._attributes['universe'])
+        self.assertEqual('post_process.py', manager.jobs[2]._attributes['executable'])
+        self.assertEqual(expected_args + ' extra1 extra2', manager.jobs[2]._attributes['arguments'])
+        self.assertEqual('../base_scenario/base_ohl_series.json,  '
+                         '../detention_basin_scenario/detention_basin_ohl_series.json, ../testkey',
+                         manager.jobs[2]._attributes['transfer_input_files'])
+        self.assertEqual('', manager.jobs[2]._attributes['transfer_output_files'])
+
+        # Job 4
+        self.assertEqual('finalize', manager.jobs[3].name)
+        self.assertEqual(3, manager.jobs[3].workflow.id)
+        self.assertEqual(3, manager.jobs[3].workflow_id)
+        self.assertEqual('finalize', manager.jobs[3]._attributes['job_name'])
+        self.assertEqual('vanilla', manager.jobs[3]._attributes['universe'])
+        self.assertEqual('update_status.py', manager.jobs[3]._attributes['executable'])
+        self.assertEqual(expected_args, manager.jobs[3]._attributes['arguments'])
+        self.assertEqual('../workflow_params.json', manager.jobs[3]._attributes['transfer_input_files'])
+        self.assertEqual('', manager.jobs[3]._attributes['transfer_output_files'])
+
+        self.assertEqual(3, id)
+        self.assertIsInstance(manager.workflow, CondorWorkflow)
+        expected_job_args = [
+            self.session.get_bind().url,
+            self.model_db.db_url,
+            str(self.workflow.resource.id),
+            str(self.workflow.id),
+            str(self.step.id),
+            '',
+            '',
+            str(manager._get_class_path(self.workflow.resource)),
+            str(manager._get_class_path(self.workflow)),
+            'testkey'
+        ]
+        self.assertEqual(expected_job_args, manager.job_args)
+        self.assertTrue(manager.prepared)

--- a/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/app_users/condor_workflow_manager_tests.py
@@ -150,7 +150,6 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
         self.assertEqual(str(self.step.id), manager.resource_workflow_step_id)
         self.assertEqual(self.step.name, manager.resource_workflow_step_name)
         self.assertEqual(self.jobs, manager.jobs)
-        self.assertFalse(manager.jobs_are_function)
         self.assertEqual(self.user, manager.user)
         self.assertEqual(self.working_directory, manager.working_directory)
         self.assertEqual(self.app, manager.app)
@@ -200,7 +199,6 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
         self.assertEqual(str(self.step.id), manager.resource_workflow_step_id)
         self.assertEqual(self.step.name, manager.resource_workflow_step_name)
         self.assertEqual(self.jobs, manager.jobs)
-        self.assertFalse(manager.jobs_are_function)
         self.assertEqual(self.user, manager.user)
         self.assertEqual(self.working_directory, manager.working_directory)
         self.assertEqual(self.app, manager.app)
@@ -230,7 +228,7 @@ class CondorWorkflowManagerTests(SqlAlchemyTestCase):
                     self.scheduler_name, jobs=None)
             self.assertTrue(False)  # This line should not be reached
         except ValueError as e:
-            self.assertEqual('Argument "jobs" is not defined or empty. Must provide at least one CondorWorkflowJobNode '
+            self.assertEqual('"jobs" is not defined or empty. Must provide at least one CondorWorkflowJobNode '
                              'or equivalent dictionary.', str(e))
 
     def test_workspace_no_path(self):


### PR DESCRIPTION
Primary changes in this Pull Request:

Added ability to generate jobs dynamically, by now allowing a function to be passed to the ResourceWorkflowCondorJobManager's jobs (along with the existing list of CondorWOrkflowJobNode or dict).

- 

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

