### PR TITLE
Show Logs on Jobs Table Only for Admins

### DIFF
--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -50,7 +50,6 @@ class ResourceStatus(ResourceViewMixin):
         app = self.get_app()
         job_manager = app.get_job_manager()
         jobs = job_manager.list_jobs()
-        show_job_table_actions = request.user and request.user.is_staff
         SessionMaker = self.get_sessionmaker()
         session = SessionMaker()
         app_user = self._AppUser.get_app_user_from_request(request, session)
@@ -82,6 +81,7 @@ class ResourceStatus(ResourceViewMixin):
 
         # Job logs contain sensitive information, so only show them to staff and app admins
         show_job_table_actions = app_user.is_staff() or app_user.get_role() == self._AppUser.ROLES.APP_ADMIN
+        session.close()
         jobs_table = JobsTable(
             jobs=filtered_jobs,
             column_fields=('id', 'name', 'creation_time', 'execute_time', 'run_time'),

--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -50,6 +50,10 @@ class ResourceStatus(ResourceViewMixin):
         app = self.get_app()
         job_manager = app.get_job_manager()
         jobs = job_manager.list_jobs()
+        show_job_table_actions = request.user and request.user.is_staff
+        SessionMaker = self.get_sessionmaker()
+        session = SessionMaker()
+        app_user = self._AppUser.get_app_user_from_request(request, session)
 
         # Filter by resource
         filtered_jobs = []
@@ -76,6 +80,8 @@ class ResourceStatus(ResourceViewMixin):
             # TODO: Should this be filtered down more? By user? Permissions?
             filtered_jobs = jobs
 
+        # Job logs contain sensitive information, so only show them to staff and app admins
+        show_job_table_actions = app_user.is_staff() or app_user.get_role() == self._AppUser.ROLES.APP_ADMIN
         jobs_table = JobsTable(
             jobs=filtered_jobs,
             column_fields=('id', 'name', 'creation_time', 'execute_time', 'run_time'),
@@ -84,6 +90,8 @@ class ResourceStatus(ResourceViewMixin):
             bordered=False,
             condensed=False,
             show_status=True,
+            actions=['logs'],
+            show_actions=show_job_table_actions,
             show_detailed_status=self.show_detailed_status
         )
 

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -86,9 +86,11 @@ class SpatialCondorJobMWV(MapWorkflowView):
         """  # noqa: E501
         step_status = current_step.get_status()
         if step_status != current_step.STATUS_PENDING:
-            return self.render_condor_jobs_table(request, resource, workflow, current_step, previous_step, next_step)
+            return self.render_condor_jobs_table(
+                request, session, resource, workflow, current_step, previous_step, next_step
+            )
 
-    def render_condor_jobs_table(self, request, resource, workflow, current_step, previous_step, next_step):
+    def render_condor_jobs_table(self, request, session, resource, workflow, current_step, previous_step, next_step):
         """
         Render a condor jobs table showing the status of the current job that is processing.
             request(HttpRequest): The request.
@@ -103,6 +105,8 @@ class SpatialCondorJobMWV(MapWorkflowView):
         app = self.get_app()
         job_manager = app.get_job_manager()
         step_job = job_manager.get_job(job_id=job_id)
+        app_user = self._AppUser.get_app_user_from_request(request, session)
+        show_job_table_actions = app_user.is_staff() or app_user.get_role() == self._AppUser.ROLES.APP_ADMIN
 
         jobs_table = JobsTable(
             jobs=[step_job],
@@ -112,6 +116,8 @@ class SpatialCondorJobMWV(MapWorkflowView):
             condensed=False,
             show_status=True,
             show_detailed_status=True,
+            actions=['logs'],
+            show_actions=show_job_table_actions,
         )
 
         # Build step cards

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -44,7 +44,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         tests_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
         self.working_dir_path = os.path.join(tests_dir, 'files', 'working_dir')
 
-        self.request = mock.MagicMock(spec=HttpRequest)
+        self.user = mock.MagicMock()
+        self.request = mock.MagicMock(spec=HttpRequest, user=self.user)
         self.request.GET = {}
         self.request.POST = {}
         self.request.path = './path'
@@ -137,7 +138,7 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         SpatialCondorJobMWV().on_get_step(self.request, self.session, self.resource, self.workflow, self.step,
                                           None, None)
 
-        mock_rcjt.assert_called_with(self.request, self.resource, self.workflow, self.step, None, None)
+        mock_rcjt.assert_called_with(self.request, self.session, self.resource, self.workflow, self.step, None, None)
 
     @mock.patch.object(ResourceWorkflowView, 'workflow_locked_for_request_user', return_value=False)
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
@@ -157,8 +158,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
 
         self.step.set_status(SpatialDatasetRWS.ROOT_STATUS_KEY, SpatialDatasetRWS.STATUS_COMPLETE)
 
-        SpatialCondorJobMWV().render_condor_jobs_table(self.request, self.resource, self.workflow, self.step,
-                                                       None, None)
+        SpatialCondorJobMWV().render_condor_jobs_table(self.request, self.session, self.resource, self.workflow,
+                                                       self.step, None, None)
 
         arg_call_list = mock_render.call_args_list[0][0][2]
         self.assertEqual(self.resource, arg_call_list['resource'])
@@ -196,8 +197,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
 
         self.step.set_status(SpatialDatasetRWS.ROOT_STATUS_KEY, SpatialDatasetRWS.STATUS_COMPLETE)
 
-        SpatialCondorJobMWV().render_condor_jobs_table(self.request, self.resource, self.workflow, self.step,
-                                                       None, None)
+        SpatialCondorJobMWV().render_condor_jobs_table(self.request, self.session, self.resource, self.workflow,
+                                                       self.step, None, None)
 
         arg_call_list = mock_render.call_args_list[0][0][2]
         self.assertEqual(self.resource, arg_call_list['resource'])


### PR DESCRIPTION
Primary changes in this Pull Request:

- The Resource Status Jobs table was modified to only show logs for admin users.
- Job logs are not sanitized and can contain sensitive information like database passwords and usernames

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

