### PR TITLE
Agwa_culvert_workflow_resource_workflow

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -205,6 +205,9 @@ class SpatialCondorJobMWV(MapWorkflowView):
         if 'run-submit' not in request.POST and 'rerun-submit' not in request.POST:
             return redirect(request.path)
 
+        # Get the workflow from the id
+        workflow = self.get_workflow(request, workflow_id, session)
+
         # Validate data if going to next step
         step = self.get_step(request, step_id, session)
 
@@ -242,6 +245,7 @@ class SpatialCondorJobMWV(MapWorkflowView):
             app=app,
             scheduler_name=scheduler_name,
             gs_engine=gs_engine,
+            resource_workflow=workflow,
         )
 
         # Serialize parameters from all previous steps into json

--- a/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
+++ b/tethysext/atcore/services/workflow_manager/condor_workflow_manager.py
@@ -26,7 +26,7 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
                                          'resources', 'resource_workflows')
 
     def __init__(self, session, resource, resource_workflow_step, user, working_directory, app, scheduler_name,
-                 jobs=None, input_files=None, gs_engine=None, *args):
+                 jobs=None, input_files=None, gs_engine=None, resource_workflow=None, *args):
         """
         Constructor.
 
@@ -40,6 +40,7 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
             scheduler_name(str): Name of the condor scheduler to use.
             jobs(list<CondorWorkflowJobNode or dict>): List of CondorWorkflowJobNodes to run.
             input_files(list<str>): List of paths to files to sends as inputs to every job. Optional.
+            resource_workflow(ResourceWorkflow): The workflow.
         """  # noqa: E501
         self.validate_jobs(jobs)
 
@@ -69,6 +70,7 @@ class ResourceWorkflowCondorJobManager(BaseWorkflowManager):
         # Important IDs
         self.resource_id = str(resource_workflow_step.workflow.resource.id)
         self.resource_name = resource_workflow_step.workflow.resource.name
+        self.resource_workflow = resource_workflow
         self.resource_workflow_id = str(resource_workflow_step.workflow.id)
         self.resource_workflow_name = resource_workflow_step.workflow.name
         self.resource_workflow_type = resource_workflow_step.workflow.DISPLAY_TYPE_SINGULAR

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -269,9 +269,10 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
 
+    @mock.patch.object(WorkflowViewMixin, 'get_workflow', return_value=None)
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=True)
     @mock.patch('tethysext.atcore.controllers.resource_workflows.mixins.WorkflowViewMixin.get_step')
-    def test_run_job__read_only(self, mock_get_step, _):
+    def test_run_job__read_only(self, mock_get_step, _, __):
         mock_get_step.return_value = self.step
         self.request.POST['run-submit'] = True
         self.request.POST['rerun-submit'] = True
@@ -284,8 +285,9 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
 
+    @mock.patch.object(WorkflowViewMixin, 'get_workflow', return_value=None)
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
-    def test_run_job_no_schedule_name(self, _):
+    def test_run_job_no_schedule_name(self, _, __):
         self.request.POST['run-submit'] = True
         self.request.POST['rerun-submit'] = True
 
@@ -295,8 +297,9 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         except RuntimeError as e:
             self.assertEqual('Improperly configured SpatialCondorJobRWS: no "scheduler" option supplied.', str(e))
 
+    @mock.patch.object(WorkflowViewMixin, 'get_workflow', return_value=None)
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
-    def test_run_job_no_jobs(self, _):
+    def test_run_job_no_jobs(self, _, __):
         self.request.POST['run-submit'] = True
         self.request.POST['rerun-submit'] = True
         self.step.options['scheduler'] = 'my_schedule'


### PR DESCRIPTION
Primary changes in this Pull Request:

Store the workflow in the condor workflow manager. Used in AGWA for being able to acces the workflow when using a callback function for dynamic jobs.

- 

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

