### PR TITLE
Allow optional columns for spatial datasets.

### DIFF
--- a/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
@@ -46,6 +46,7 @@ class SpatialDatasetRWS(SpatialResourceWorkflowStep):
             'template_dataset': self.DEFAULT_DATASET,
             'read_only_columns': [],
             'plot_columns': [],
+            'optional_columns': [],
             'max_rows': self.DEFAULT_MAX_ROWS,
             'empty_rows': self.DEFAULT_EMPTY_ROWS
         })

--- a/tethysext/atcore/public/resource_workflows/spatial_dataset_mwv.js
+++ b/tethysext/atcore/public/resource_workflows/spatial_dataset_mwv.js
@@ -338,8 +338,13 @@ var SPATIAL_DATASET_MWV = (function() {
                 name: m_y_column[i],
             };
 
-            data.push(series);
-            layouts.push(layout);
+            if (!y_values.every((item) => item == -99999.9)) {
+                data.push(series);
+                layouts.push(layout);
+            }
+        }
+        if (layouts.length == 0) {
+            return;
         }
         let layout = layouts[0];
 

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_dataset_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_dataset_mwv_tests.py
@@ -122,6 +122,36 @@ class SpatialDatasetMwvTests(WorkflowViewTestCase):
         self.assertEqual([b'{"success": true}'], ret.__dict__['_container'])
 
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch.object(SpatialDatasetMWV, 'get_step')
+    @mock.patch.object(SpatialDatasetMWV, 'get_workflow')
+    @mock.patch.object(ResourceWorkflowView, 'user_has_active_role')
+    def test_save_spatial_data_optional_columns(self, mock_user_role, mock_get_workflow, mock_get_step, _):
+        optional_step1 = SpatialDatasetRWS(
+            geoserver_name='geo_server',
+            map_manager=mock.MagicMock(),
+            spatial_manager=mock.MagicMock(),
+            name='name1_optional',
+            help='help1_optional',
+            order=1,
+            options={
+                'max_rows': 1000,
+                'template_dataset': pd.DataFrame(columns=['Time (min)', 'Optional']),
+                'column': [],
+                'optional_columns': ['Optional'],
+            }
+        )
+        mock_user_role.return_value = True
+        mock_get_workflow.return_value = self.workflow
+        mock_get_step.return_value = optional_step1
+
+        ret = SpatialDatasetMWV().save_spatial_data(self.request, self.workflow.id, optional_step1.id,
+                                                    back_url=self.back_url, resource=self.resource,
+                                                    session=self.session)
+
+        self.assertIsInstance(ret, JsonResponse)
+        self.assertEqual([b'{"success": true}'], ret.__dict__['_container'])
+
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
     def test_process_step_data(self, _):
         resource = mock.MagicMock(spec=ModelDatabase)
 

--- a/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
@@ -50,6 +50,7 @@ class SpatialDatasetRWSTests(SqlAlchemyTestCase):
             'template_dataset': self.instance.DEFAULT_DATASET,
             'read_only_columns': [],
             'plot_columns': [],
+            'optional_columns': [],
             'max_rows': self.instance.DEFAULT_MAX_ROWS,
             'empty_rows': self.instance.DEFAULT_EMPTY_ROWS,
             'geocode_enabled': False,


### PR DESCRIPTION
Primary changes in this Pull Request:

Updated SpatialDatasetMWV and SpatialDatasetRWS to allow for optional columns.  When an optional column is found to be empty, it is filled in with NODATA values.  Optional columns consisting entirely of NODATA values are not plotted.

- 

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

