### PR TITLE
made resource group display optional

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -35,7 +35,7 @@ class ManageResources(ResourceViewMixin):
     http_method_names = ['get', 'post', 'delete']
     enable_groups = False
     collapse_groups = False
-    highlight_groups = True
+    highlight_groups = False
 
     ACTION_LAUNCH = 'launch'
     ACTION_PROCESSING = 'processing'
@@ -160,6 +160,7 @@ class ManageResources(ResourceViewMixin):
                 resource_card['debugging']['id'] = str(resource.id)
                 resource_card['has_parents'] = len(resource.parents) > 0
                 resource_card['has_children'] = len(resource.children) > 0
+                resource_card['children'] = []
 
                 # Get resource action parameters
                 action_dict = self.get_resource_action(
@@ -174,8 +175,11 @@ class ManageResources(ResourceViewMixin):
                 resource_card['action_href'] = action_dict['href']
 
                 # Build child resources recursively
-                resource_card['children'] = build_resource_cards(resource.children, level=level+1) \
-                    if resource.children else []
+                if self.enable_groups:
+                    resource_card['children'] = build_resource_cards(resource.children, level=level+1) \
+                        if resource.children else []
+
+                # append resource to resource_cards
                 resource_cards.append(resource_card)
 
             # Only attempt to sort if the sort field is a valid attribute of _Resource
@@ -213,6 +217,7 @@ class ManageResources(ResourceViewMixin):
             'pagination_info': pagination_info,
             'show_select_column': self.enable_groups and has_permission(request, 'create_resource'),
             'show_group_buttons': self.enable_groups,
+            'enable_groups': self.enable_groups,
             'show_new_group_button': self.enable_groups and has_permission(request, 'create_resource'),
             'show_new_button': has_permission(request, 'create_resource'),
             'show_debugging_info': request_app_user.is_staff(),

--- a/tethysext/atcore/templates/atcore/components/resource_row.html
+++ b/tethysext/atcore/templates/atcore/components/resource_row.html
@@ -10,8 +10,8 @@
 
   {# NAME VALUE #}
   <td class="name" data-id="{{ resource.name }}">
-    {% if resource.has_parents %}<span style="display: inline-block; width: {% widthratio 25 1 resource.level %}px;" class="child-spacer level-{{ resource.level }}"></span>{% endif %}
-    {% if resource.has_children %}<button {% if not collapse_groups %}class="expanded"{% endif %} data-ts-toggle="table-row-collapse" data-ts-target=".child-{{ resource.id }}" type="button"><i class="bi bi-chevron-right"></i></button> {% endif %}
+    {% if enable_groups and resource.has_parents %}<span style="display: inline-block; width: {% widthratio 25 1 resource.level %}px;" class="child-spacer level-{{ resource.level }}"></span>{% endif %}
+    {% if enable_groups and resource.has_children %}<button {% if not collapse_groups %}class="expanded"{% endif %} data-ts-toggle="table-row-collapse" data-ts-target=".child-{{ resource.id }}" type="button"><i class="bi bi-chevron-right"></i></button> {% endif %}
     <a href="{{ resource.action_href }}">{{ resource.name }}</a>
   </td>
 


### PR DESCRIPTION
Primary changes in this Pull Request:

- Made resource group display in manage_resource optional

Please review the checklist before submitting the Pull Request:

- [X] Pull request has a meaning full name (not just the commit message from of your last commit)
- [X] Code has been linted using flake8
- [X] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

No tests for group functionality yet.

