### PR TITLE
Allow links on summary tab table.

### DIFF
--- a/tethysext/atcore/templates/atcore/resources/tabs/summary_tab.html
+++ b/tethysext/atcore/templates/atcore/resources/tabs/summary_tab.html
@@ -29,8 +29,8 @@
           <tbody>
             {% for key, value in table.items %}
               <tr>
-                <td class="name">{{ key }}</td>
-                <td>{{ value }}</td>
+                <td class="name">{{ key | safe }}</td>
+                <td>{{ value | safe }}</td>
               </tr>
             {% endfor %}
           </tbody>


### PR DESCRIPTION
Primary changes in this Pull Request:

For the details summary table, allow the two <td>'s (which contain a key and value) to have links on them.

- 

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

