### PR TITLE
Fix for displaying resource groups.

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -160,7 +160,6 @@ class ManageResources(ResourceViewMixin):
                 resource_card['debugging']['id'] = str(resource.id)
                 resource_card['has_parents'] = len(resource.parents) > 0
                 resource_card['has_children'] = len(resource.children) > 0
-                resource_card['children'] = []
 
                 # Get resource action parameters
                 action_dict = self.get_resource_action(
@@ -175,9 +174,8 @@ class ManageResources(ResourceViewMixin):
                 resource_card['action_href'] = action_dict['href']
 
                 # Build child resources recursively
-                if self.enable_groups:
-                    resource_card['children'] = build_resource_cards(resource.children, level=level+1) \
-                        if resource.children else []
+                resource_card['children'] = build_resource_cards(resource.children, level=level+1) \
+                    if self.enable_groups and resource.children else []
 
                 # append resource to resource_cards
                 resource_cards.append(resource_card)


### PR DESCRIPTION
Previous commit got rid of resource.children when setting resource_card['children'] to empty list.
Keep the children around, they are needed when building child resources recursively.
If not enabling groups or no children, then we can set the resource_card children to an empty list.

Primary changes in this Pull Request:

- Enable list of models under parent.

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

