### PR TITLE
Added param_class option for SpatialInputMWV

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
@@ -76,6 +76,12 @@ class SpatialInputMWV(MapWorkflowView):
         """
         # Prepare attributes form
         attributes = current_step.options.get('attributes', None)
+        param_class = current_step.options.get('param_class', None)
+        if not attributes and param_class:
+            package, p_class = param_class.rsplit('.', 1)
+            mod = __import__(package, fromlist=[p_class])
+            ParamClass = getattr(mod, p_class, None)
+            attributes = ParamClass(request=request, session=session, resource=resource) if ParamClass else None
 
         if attributes is not None:
             attributes_form = generate_django_form(attributes)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -189,6 +189,30 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
                 return_value=False)
     @mock.patch('tethysext.atcore.models.app_users.resource.Resource.is_locked_for_request_user',
                 return_value=False)
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.map_workflows.spatial_input_mwv.generate_django_form')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch.object(ResourceWorkflowStep, 'get_parameter')
+    @mock.patch.object(ResourceWorkflowView, 'user_has_active_role', return_value=True)
+    def test_process_step_options_with_param_class(self, _, mock_params, mock_get_map_manager, mock_form, __, ___):
+        mock_params.return_value = {'geometry': 'shapes and such'}
+        map_view = MapView()
+        map_view.layers = []
+        mock_get_map_manager.return_value = map_view
+        mock_form.return_view = {}
+
+        resource = mock.MagicMock()
+        self.context['map_view'] = map_view
+        self.context['layer_groups'] = [{}]
+        self.step1.options['param_class'] = 'os.test_foo_param_class_doesnt_exist'
+
+        instance = SpatialInputMWV()
+        instance.map_type = 'tethys_map_view'
+        instance.process_step_options(self.request, self.session, self.context, resource, self.step1, None, self.step2)
+
+    @mock.patch('tethysext.atcore.models.app_users.resource_workflow.ResourceWorkflow.is_locked_for_request_user',
+                return_value=False)
+    @mock.patch('tethysext.atcore.models.app_users.resource.Resource.is_locked_for_request_user',
+                return_value=False)
     @mock.patch.object(MapView, 'get_map_manager')
     @mock.patch.object(ResourceWorkflowStep, 'get_parameter')
     @mock.patch.object(ResourceWorkflowView, 'user_has_active_role', return_value=True)


### PR DESCRIPTION
Primary changes in this Pull Request:

- Allows use of 'attributes' option when simple input is needed.
- Allows a similar 'param_class' argument where more dynamic input is needed, via a request, session, or resource.
- The default is 'attributes' but 'param_class' is checked if 'attributes' is not used.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

