### PR TITLE
Fix Manage Resource Grouping Bug

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -372,7 +372,9 @@ class ManageResources(ResourceViewMixin):
             list<Resources>: the list of resources to render on the manage_resources page.
         """
         _Resource = self.get_resource_model()
-        return request_app_user.get_resources(session, request, of_type=_Resource, include_children=False)
+        return request_app_user.get_resources(
+            session, request, of_type=_Resource, include_children=not self.enable_groups
+        )
 
     def perform_custom_delete_operations(self, session, request, resource):
         """

--- a/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
@@ -401,7 +401,7 @@ class ManageResourcesTests(SqlAlchemyTestCase):
                 'href': mock_reverse(),
             }, ret)
 
-    def test_get_resources(self):
+    def test_get_resources_groups_disabled(self):
         mock_request = self.request_factory.get('/foo/bar/')
         mock_session = mock.MagicMock()
         mock_request_app_user = mock.MagicMock()
@@ -409,6 +409,22 @@ class ManageResourcesTests(SqlAlchemyTestCase):
             mock_get_resource_model.return_value = 'resource_type'
             # Call the method
             manage_resources = ManageResources()
+            manage_resources.enable_groups = False
+            manage_resources.get_resources(mock_session, mock_request, mock_request_app_user)
+
+        # Test the results
+        mock_request_app_user.get_resources.assert_called_with(mock_session, mock_request, of_type='resource_type',
+                                                               include_children=True)
+
+    def test_get_resources_groups_enabled(self):
+        mock_request = self.request_factory.get('/foo/bar/')
+        mock_session = mock.MagicMock()
+        mock_request_app_user = mock.MagicMock()
+        with mock.patch.object(ResourceViewMixin, 'get_resource_model') as mock_get_resource_model:
+            mock_get_resource_model.return_value = 'resource_type'
+            # Call the method
+            manage_resources = ManageResources()
+            manage_resources.enable_groups = True
             manage_resources.get_resources(mock_session, mock_request, mock_request_app_user)
 
         # Test the results


### PR DESCRIPTION
Primary changes in this Pull Request:

- Resources that had parents were not showing up on the manage resources page, even when grouping was disabled.
- Fixed an issue with the `ManageResources.get_resources()` method.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

