### PR TITLE
Separate launch and row links

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -172,6 +172,7 @@ class ManageResources(ResourceViewMixin):
                 resource_card['action'] = action_dict['action']
                 resource_card['action_title'] = action_dict['title']
                 resource_card['action_href'] = action_dict['href']
+                resource_card['info_href'] = self.get_info_url(request, resource)
 
                 # Build child resources recursively
                 resource_card['children'] = build_resource_cards(resource.children, level=level+1) \
@@ -325,6 +326,13 @@ class ManageResources(ResourceViewMixin):
         Get the URL for the Resource Error button.
         """
         return reverse(f'{self._app.url_namespace}:{resource.SLUG}_resource_details', args=[resource.id])
+
+    def get_info_url(self, request, resource):
+        """
+        Get the URL for the Resource name link and row click. Defaults 
+        """
+        # Default to the same as the launch url for backwards compatibility
+        return self.get_launch_url(request, resource)
 
     def get_resource_action(self, session, request, request_app_user, resource):
         """

--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -32,6 +32,11 @@ class ManageResources(ResourceViewMixin):
     template_name = 'atcore/app_users/manage_resources.html'
     base_template = 'atcore/app_users/base.html'
     default_action_title = 'Launch'
+    default_action_icon = "bi-chevron-right"
+    error_action_title = "Error"
+    error_action_icon = "bi-x-lg"
+    working_action_title = "Processing"
+    working_action_icon = "bi-arrow-clockwise"
     http_method_names = ['get', 'post', 'delete']
     enable_groups = False
     collapse_groups = False
@@ -172,6 +177,7 @@ class ManageResources(ResourceViewMixin):
                 resource_card['action'] = action_dict['action']
                 resource_card['action_title'] = action_dict['title']
                 resource_card['action_href'] = action_dict['href']
+                resource_card['action_icon'] = action_dict['icon']
                 resource_card['info_href'] = self.get_info_url(request, resource)
 
                 # Build child resources recursively
@@ -329,7 +335,7 @@ class ManageResources(ResourceViewMixin):
 
     def get_info_url(self, request, resource):
         """
-        Get the URL for the Resource name link and row click. Defaults 
+        Get the URL for the Resource name link and row click.
         """
         # Default to the same as the launch url for backwards compatibility
         return self.get_launch_url(request, resource)
@@ -351,22 +357,25 @@ class ManageResources(ResourceViewMixin):
         if status in resource.ERROR_STATUSES:
             return {
                 'action': self.ACTION_ERROR,
-                'title': 'Error',
-                'href': self.get_error_url(request, resource)
+                'title': self.error_action_title,
+                'href': self.get_error_url(request, resource),
+                'icon': self.error_action_icon,
             }
 
         elif status in resource.WORKING_STATUSES:
             return {
                 'action': self.ACTION_PROCESSING,
-                'title': 'Processing',
-                'href': self.get_working_url(request, resource)
+                'title': self.working_action_title,
+                'href': self.get_working_url(request, resource),
+                'icon': self.working_action_icon,
             }
 
         else:
             return {
                 'action': self.ACTION_LAUNCH,
                 'title': self.default_action_title,
-                'href': self.get_launch_url(request, resource)
+                'href': self.get_launch_url(request, resource),
+                'icon': self.default_action_icon,
             }
 
     def get_resources(self, session, request, request_app_user):

--- a/tethysext/atcore/templates/atcore/components/resource_row.html
+++ b/tethysext/atcore/templates/atcore/components/resource_row.html
@@ -12,16 +12,16 @@
   <td class="name" data-id="{{ resource.name }}">
     {% if enable_groups and resource.has_parents %}<span style="display: inline-block; width: {% widthratio 25 1 resource.level %}px;" class="child-spacer level-{{ resource.level }}"></span>{% endif %}
     {% if enable_groups and resource.has_children %}<button {% if not collapse_groups %}class="expanded"{% endif %} data-ts-toggle="table-row-collapse" data-ts-target=".child-{{ resource.id }}" type="button"><i class="bi bi-chevron-right"></i></button> {% endif %}
-    <a href="{{ resource.action_href }}">{{ resource.name }}</a>
+    <a href="{{ resource.info_href }}">{{ resource.name }}</a>
   </td>
 
   {# DESCRIPTION VALUE #}
   {% if not resource.description %}
-  <td class="description" data-id="{{ resource.description }}" onclick="window.document.location='{{ resource.action_href }}';" style="cursor: pointer;">
+  <td class="description" data-id="{{ resource.description }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     <i><font color="#A8A8A8">No Description</font></i>
   </td>
   {% else %}
-  <td class="description" data-id="{{ resource.description }}" onclick="window.document.location='{{ resource.action_href }}';" style="cursor: pointer;">
+  <td class="description" data-id="{{ resource.description }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     <span>{{ resource.description }}</span>
   </td>
   {% endif %}
@@ -41,17 +41,17 @@
 
   {# CREATED BY VALUE #}
   {% if resource.created_by %}
-  <td class="created_by" data-id="{{ resource.created_by }}" onclick="window.document.location='{{ resource.action_href }}';" style="cursor: pointer;">
+  <td class="created_by" data-id="{{ resource.created_by }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     {% if resource.created_by == '_staff_user' %}staff{% else %}{{ resource.created_by }}{% endif %}
   </td>
   {% else %}
-  <td class="created_by" data-id="Unknown" onclick="window.document.location='{{ resource.action_href }}';" style="cursor: pointer;">
+  <td class="created_by" data-id="Unknown" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     <i><font color="#A8A8A8">Unknown</font></i>
   </td>
   {% endif %}
 
   {# DATE CREATED VALUE #}
-  <td class="date_created" data-id="{{ resource.date_created }}" onclick="window.document.location='{{ resource.action_href }}';" style="cursor: pointer;">
+  <td class="date_created" data-id="{{ resource.date_created }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     {{ resource.date_created }} UTC
   </td>
 

--- a/tethysext/atcore/templates/atcore/components/resource_row.html
+++ b/tethysext/atcore/templates/atcore/components/resource_row.html
@@ -72,11 +72,11 @@
         <a class="btn btn-outline-secondary btn-delete-manage btn-delete btn-flat" href="javascript:void(0);" data-id="{{ resource.id }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Delete"><span class="bi bi-trash"></span></a>
       {% endif %}
       {% if resource.action == 'processing' %}
-        <a class="btn btn-s btn-warning btn-flat btn-action btn-resource-processing" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi bi-arrow-clockwise"></span></a>
+        <a class="btn btn-s btn-warning btn-flat btn-action btn-resource-processing" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi {{ resource.action_icon }}"></span></a>
       {% elif resource.action == 'error' %}
-        <a class="btn btn-s btn-error btn-flat btn-action btn-resource-error" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi bi-x-lg"></span></a>
+        <a class="btn btn-s btn-error btn-flat btn-action btn-resource-error" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi {{ resource.action_icon }}"></span></a>
       {% else %}
-        <a class="btn btn-s btn-primary btn-flat btn-action btn-resource-launch" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi bi-chevron-right"></span></a>
+        <a class="btn btn-s btn-primary btn-flat btn-action btn-resource-launch" href="{{ resource.action_href }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ resource.action_title }}"><span class="bi {{ resource.action_icon }}"></span></a>
       {% endif %}
     </div>
   </td>


### PR DESCRIPTION
Primary changes in this Pull Request:

- Allow different URLs to be specified for the ManageResources row/name link and the Launch button link via a new hook: `get_info_url()`.
- Make it easier to customize the icons and names of the different action buttons on ManageResources rows.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

