### PR TITLE
SpatialInputMWV store_imagery fix.

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_input_mwv.py
@@ -590,7 +590,7 @@ class SpatialInputMWV(MapWorkflowView):
                 # tmp_zip_file.write('/tmp/4326.prj', coverage_name + '.prj')  # DEBUGGING ONLY - WGS84
 
             # Get the GeoServer engine, and create a layer from the zip file
-            gs_engine = self.get_app.get_spatial_dataset_service(self.geoserver_name, as_engine=True)
+            gs_engine = self.get_app().get_spatial_dataset_service(self.geoserver_name, as_engine=True)
             workspace = self._SpatialManager.WORKSPACE
             layer_id = f"{workspace}:{coverage_name}"
 

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_input_mwv_tests.py
@@ -763,7 +763,7 @@ class SpatialInputMwvTests(WorkflowViewTestCase):
 
         # Test for an exception being raised
         exc_str = 'test exception'
-        mock_get_app.get_spatial_dataset_service().create_coverage_layer.side_effect = [Exception(exc_str)]
+        mock_get_app().get_spatial_dataset_service().create_coverage_layer.side_effect = [Exception(exc_str)]
         with self.assertRaises(RuntimeError) as cm:
             with open(self.BadProjection_zip, 'rb') as f:
                 test_file = InMemoryUploadedFile(


### PR DESCRIPTION
Fix getting the geoserver engine from the app, which is needed to create the coverage layer.
Updated test.

Primary changes in this Pull Request:

- 

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

