### PR TITLE
Reduce how often the jobs tables update status to reduce load on server

### DIFF
--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -80,7 +80,10 @@ class ResourceStatus(ResourceViewMixin):
             filtered_jobs = jobs
 
         # Job logs contain sensitive information, so only show them to staff and app admins
-        show_job_table_actions = app_user.is_staff() or app_user.get_role() == self._AppUser.ROLES.APP_ADMIN
+        show_job_table_actions = app_user.is_staff() or app_user.get_role() in [
+            self._AppUser.ROLES.APP_ADMIN,
+            self._AppUser.ROLES.ORG_ADMIN
+        ]
         session.close()
         jobs_table = JobsTable(
             jobs=filtered_jobs,

--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -90,9 +90,10 @@ class ResourceStatus(ResourceViewMixin):
             bordered=False,
             condensed=False,
             show_status=True,
-            actions=['logs'],
+            actions=['logs', 'resubmit'],
             show_actions=show_job_table_actions,
-            show_detailed_status=self.show_detailed_status
+            show_detailed_status=self.show_detailed_status,
+            refresh_interval=30000,
         )
 
         context = {

--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -29,6 +29,7 @@ class ResourceStatus(ResourceViewMixin):
     base_template = 'atcore/app_users/base.html'
     http_method_names = ['get']
     show_detailed_status = True
+    jobs_table_refresh_interval = 30000  # ms
 
     def get(self, request, *args, **kwargs):
         """
@@ -96,7 +97,7 @@ class ResourceStatus(ResourceViewMixin):
             actions=['logs', 'resubmit'],
             show_actions=show_job_table_actions,
             show_detailed_status=self.show_detailed_status,
-            refresh_interval=30000,
+            refresh_interval=self.jobs_table_refresh_interval,
         )
 
         context = {

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -27,6 +27,7 @@ class SpatialCondorJobMWV(MapWorkflowView):
     template_name = 'atcore/resource_workflows/spatial_condor_job_mwv.html'
     valid_step_classes = [SpatialCondorJobRWS]
     previous_steps_selectable = True
+    jobs_table_refresh_interval = 30000  # ms
 
     def process_step_options(self, request, session, context, resource, current_step, previous_step, next_step):
         """
@@ -122,7 +123,7 @@ class SpatialCondorJobMWV(MapWorkflowView):
             show_detailed_status=True,
             actions=['logs'],
             show_actions=show_job_table_actions,
-            refresh_interval=30000,
+            refresh_interval=self.jobs_table_refresh_interval,
         )
 
         # Build step cards

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -122,6 +122,7 @@ class SpatialCondorJobMWV(MapWorkflowView):
             show_detailed_status=True,
             actions=['logs'],
             show_actions=show_job_table_actions,
+            refresh_interval=30000,
         )
 
         # Build step cards


### PR DESCRIPTION
Primary changes in this Pull Request:

- The jobs tables were DoSing the server b/c they would send a bunch of ajax calls every 5 seconds.
- Reduced how often they update status to every 30 seconds.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

