### PR TITLE
Added XMS Tool resource workflow step and view

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/__init__.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/__init__.py
@@ -8,3 +8,4 @@
 """
 from tethysext.atcore.controllers.resource_workflows.workflow_views.set_status_wv import SetStatusWV  # noqa: F401, E501
 from tethysext.atcore.controllers.resource_workflows.workflow_views.form_input_wv import FormInputWV  # noqa: F401, E501
+from tethysext.atcore.controllers.resource_workflows.workflow_views.xms_tool_wv import generate_django_form_xmstool, XMSToolWV  # noqa: F401, E501

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -1,9 +1,9 @@
 """
 ********************************************************************************
 * Name: xms_tool_wv.py
-* Author: mmlebaron, glarsen
-* Created On: October 18, 2019
-* Copyright: (c) Aquaveo 2019
+* Author: dgallup
+* Created On: December, 2023
+* Copyright: (c) Aquaveo 2023
 ********************************************************************************
 """
 import logging
@@ -28,7 +28,6 @@ xmstool_widget_map = {
     #     ),
     'Boolean':
         lambda po, p, name: forms.BooleanField(
-            # initial=po.param.inspect_value(name) or p.default, required=False
             initial=p.value or p.default,
             required=False,
         ),
@@ -38,21 +37,16 @@ xmstool_widget_map = {
     #     ),
     'String':
         lambda po, p, name: forms.CharField(
-            # initial=po.param.inspect_value(name) or p.default,
             initial=p.value or p.default,
         ),
     'ObjectSelector':
         lambda po, p, name: forms.ChoiceField(
-            # initial=po.param.inspect_value(name) or p.default,
             initial=p.value or p.default,
             widget=Select2Widget,
-            # choices=p.get_range().items(),
-            # choices=p.objects,
             choices=list(enumerate(p.objects)),
         ),
     'Number':
         lambda po, p, name: forms.FloatField(
-            # initial=po.param.inspect_value(name) or p.default,
             initial=p.value or p.default,
         ),
     # param.FileSelector:
@@ -61,13 +55,11 @@ xmstool_widget_map = {
     #     ),
     'Integer':
         lambda po, p, name: forms.IntegerField(
-            # initial=po.param.inspect_value(name) or p.default,
             initial=p.value or p.default,
         ),
 }
 
 
-# class XMSToolWV(FormInputWV):
 class XMSToolWV(ResourceWorkflowView):
     """
     Controller for XMSToolRWS.

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -188,7 +188,7 @@ class XMSToolWV(ResourceWorkflowView):
 
 
 def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=None, form_field_prefix=None,
-                                 read_only=False, arg_mapping=None):
+                                 read_only=False, arg_mapping=None, setup_func=None):
     """
     Create a Django form from a Parameterized object.
 
@@ -227,8 +227,10 @@ def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=
                 precedence += 1
         return arguments_dict
 
+    if not setup_func:
+        setup_func = _setup_parameterized_args
     tool_arguments = xms_tool_class.initial_arguments()
-    argument_params = _setup_parameterized_args(tool_arguments)
+    argument_params = setup_func(tool_arguments)
 
     # Create Django Form class dynamically
     class_name = '{}Form'.format(xms_tool_class.name.title()).replace(' ', '')
@@ -251,9 +253,9 @@ def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=
 
                     # Query on the resource, find the correct resource, and then look for the right arguments
                     resources = session.query(resource_class).all()
-                    for r in resources:
-                        if r == resource:
-                            datasets = getattr(r, arg_atts['source_attr'])
+                    for res in resources:
+                        if res == resource:
+                            datasets = getattr(res, arg_atts['source_attr'])
                             for dataset in datasets:
                                 attr_value = getattr(dataset, arg_atts['attr'])
                                 if attr_value in arg_atts['valid_values']:

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -1,0 +1,261 @@
+"""
+********************************************************************************
+* Name: xms_tool_wv.py
+* Author: mmlebaron, glarsen
+* Created On: October 18, 2019
+* Copyright: (c) Aquaveo 2019
+********************************************************************************
+"""
+import logging
+
+from django import forms
+from django_select2.forms import Select2Widget
+
+from tethysext.atcore.controllers.resource_workflows.workflow_view import ResourceWorkflowView
+from tethysext.atcore.models.resource_workflow_steps.xms_tool_rws import XMSToolRWS
+
+# from bokeh.embed import server_document
+
+log = logging.getLogger(f'tethys.{__name__}')
+
+
+xmstool_widget_map = {
+    # param.Foldername:
+    #     lambda po, p, name: forms.FilePathField(
+    #         initial=po.param.inspect_value(name) or p.default,
+    #         path=p.search_paths,
+    #     ),
+    'Boolean':
+        lambda po, p, name: forms.BooleanField(
+            # initial=po.param.inspect_value(name) or p.default, required=False
+            initial=p.value or p.default,
+            required=False,
+        ),
+    # param.Filename:
+    #     lambda po, p, name: forms.FileField(
+    #         initial=po.param.inspect_value(name) or p.default,
+    #     ),
+    'String':
+        lambda po, p, name: forms.CharField(
+            # initial=po.param.inspect_value(name) or p.default,
+            initial=p.value or p.default,
+        ),
+    'ObjectSelector':
+        lambda po, p, name: forms.ChoiceField(
+            # initial=po.param.inspect_value(name) or p.default,
+            initial=p.value or p.default,
+            widget=Select2Widget,
+            # choices=p.get_range().items(),
+            # choices=p.objects,
+            choices=list(enumerate(p.objects)),
+        ),
+    'Number':
+        lambda po, p, name: forms.FloatField(
+            # initial=po.param.inspect_value(name) or p.default,
+            initial=p.value or p.default,
+        ),
+    # param.FileSelector:
+    #     lambda po, p, name: forms.ChoiceField(
+    #         initial=po.param.inspect_value(name) or p.default,
+    #     ),
+    'Integer':
+        lambda po, p, name: forms.IntegerField(
+            # initial=po.param.inspect_value(name) or p.default,
+            initial=p.value or p.default,
+        ),
+}
+
+
+# class XMSToolWV(FormInputWV):
+class XMSToolWV(ResourceWorkflowView):
+    """
+    Controller for XMSToolRWS.
+    """
+    template_name = 'atcore/resource_workflows/form_input_wv.html'
+    valid_step_classes = [XMSToolRWS]
+
+    def process_step_options(self, request, session, context, resource, current_step, previous_step, next_step):
+        """
+        Hook for processing step options (i.e.: modify map or context based on step options).
+
+        Args:
+            request(HttpRequest): The request.
+            session(sqlalchemy.orm.Session): Session bound to the steps.
+            context(dict): Context object for the map view template.
+            resource(Resource): the resource for this request.
+            current_step(ResourceWorkflowStep): The current step to be rendered.
+            previous_step(ResourceWorkflowStep): The previous step.
+            next_step(ResourceWorkflowStep): The next step.
+        """
+        # Status style
+        form_title = current_step.options.get('form_title', current_step.name) or current_step.name
+        form_values = current_step.get_parameter('form-values')
+
+        current_step.options.pop('param_class', None)
+        package, p_class = current_step.options['xmstool_class'].rsplit('.', 1)
+        mod = __import__(package, fromlist=[p_class])
+        XMSToolClass = getattr(mod, p_class)
+
+        # Get the renderer option
+        renderer = current_step.options['renderer']
+        context.update({'renderer': renderer})
+
+        # Django Renderer
+        if renderer == 'django':
+            tool = XMSToolClass()
+            form = generate_django_form_xmstool(tool, form_values, form_field_prefix='param-form-',
+                                                read_only=self.is_read_only(request, current_step))()
+
+            # Save changes to map view and layer groups
+            context.update({
+                'read_only': self.is_read_only(request, current_step),
+                'form_title': form_title,
+                'form': form,
+            })
+
+    def process_step_data(self, request, session, step, resource, current_url, previous_url, next_url):
+        """
+        Hook for processing user input data coming from the map view. Process form data found in request.POST and request.GET parameters and then return a redirect response to one of the given URLs. Only called if the user has an active role.
+
+        Args:
+            request(HttpRequest): The request.
+            session(sqlalchemy.orm.Session): Session bound to the steps.
+            step(ResourceWorkflowStep): The step to be updated.
+            resource(Resource): the resource for this request.
+            current_url(str): URL to step.
+            previous_url(str): URL to the previous step.
+            next_url(str): URL to the next step.
+
+        Returns:
+            HttpResponse: A Django response.
+        """  # noqa: E501
+        step.options.pop('param_class', None)
+        package, p_class = step.options['xmstool_class'].rsplit('.', 1)
+        mod = __import__(package, fromlist=[p_class])
+        XMSToolClass = getattr(mod, p_class)
+        form_values = step.get_parameter('form-values')
+        if step.options['renderer'] == 'django':
+            tool = XMSToolClass()
+            form = generate_django_form_xmstool(tool, form_values, form_field_prefix='param-form-')(request.POST)
+            form_values = {}
+
+            if not form.is_valid():
+                raise RuntimeError('form is invalid')
+
+            # Get the form from the post
+            # loop through items and set the params
+            for p in request.POST:
+                if p.startswith('param-form-'):
+                    try:
+                        param_name = p[11:]
+                        form_values[param_name] = form.cleaned_data[p]
+                    except ValueError as e:
+                        raise RuntimeError('error setting param data: {}'.format(e))
+
+            step.set_parameter('resource_name', step.workflow.resource.name)
+            temp_values = step.get_parameter('form-values')
+            temp_values['value'] = form_values
+            step.set_parameter('form-values', temp_values)
+
+        # Save parameters
+        session.commit()
+
+        # Validate the parameters
+        step.validate()
+
+        # Set the status
+        step.set_status(status=step.STATUS_COMPLETE)
+        session.commit()
+
+        response = super().process_step_data(
+            request=request,
+            session=session,
+            step=step,
+            resource=resource,
+            current_url=current_url,
+            previous_url=previous_url,
+            next_url=next_url
+        )
+
+        return response
+
+
+def generate_django_form_xmstool(xms_tool_class, form_values, form_field_prefix=None, read_only=False):
+    """
+    Create a Django form from a Parameterized object.
+
+    Args:
+        xms_tool_class(class): the XMS tool class.
+        form_values(dict): dict of initial values to assign
+        form_field_prefix(str): A prefix to prepend to form fields
+        read_only(bool): Read only flag
+    Returns:
+        Form: a Django form with fields matching the parameters of the given parameterized object.
+    """
+    def _setup_parameterized_args(arguments):
+        """Takes the XMSToolArgument list and turns it into a dictionary of Param types.
+
+        Args:
+            arguments (List[Argument]): List of tool arguments.
+
+        Returns:
+            (Dict[str, Parameter]): List of Parameter objects.
+        """
+        arguments_dict = {}
+        argument_precedence = {}
+        precedence = 100
+        for argument in arguments:
+            arg_param = argument.get_param(precedence)
+            if argument.value is not None:
+                arg_param.value = argument.value
+            displayed = True
+            if argument.io_direction == 2 and argument.type in ['integer', 'float', 'string']:
+                displayed = False
+            if displayed:
+                argument_precedence[argument.name] = precedence
+                arguments_dict[argument.name] = arg_param
+                precedence += 1
+        return arguments_dict
+
+    tool_arguments = xms_tool_class.initial_arguments()
+    argument_params = _setup_parameterized_args(tool_arguments)
+
+    # Create Django Form class dynamically
+    class_name = '{}Form'.format(xms_tool_class.name.title()).replace(' ', '')
+    form_class = type(class_name, (forms.Form,), dict(forms.Form.__dict__))
+
+    # Sort parameters based on precedence
+    sorted_params = sorted(argument_params.items(), key=lambda p: p[1].precedence or 9999)
+
+    # Fill in form values if necessary
+    if form_values:
+        for form_value in form_values.items():
+            for param in sorted_params:
+                if param[0] in form_value[1]:
+                    param[1]._value = form_value[1][param[0]]
+
+    for cur_p in sorted_params:
+        p_name = cur_p[0]
+
+        # Prefix parameter name if prefix provided
+        if form_field_prefix is not None:
+            p_name = form_field_prefix + p_name
+
+        # Get appropriate Django field/widget based on param type
+        form_class.base_fields[p_name] = xmstool_widget_map[cur_p[1].type](argument_params, cur_p[1], cur_p[0])
+
+        # Set label with param label if set, otherwise derive from parameter name
+        label = cur_p[1].label
+        form_class.base_fields[p_name].label = cur_p[0].replace("_", " ").title() if not label else label
+
+        # If form is read-only, set disabled attribute
+        form_class.base_fields[p_name].widget.attrs.update({'disabled': read_only})
+
+        # Help text displayed on hover over field
+        if cur_p[1].doc:
+            form_class.base_fields[p_name].widget.attrs.update({'title': cur_p[1].doc})
+
+        # Set required state from allow_None
+        # form_class.base_fields[p_name].required = cur_p.allow_None
+
+    return form_class

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -187,8 +187,8 @@ class XMSToolWV(ResourceWorkflowView):
         return response
 
 
-def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=None, form_field_prefix=None, read_only=False,
-                                 arg_mapping = {}):
+def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=None, form_field_prefix=None,
+                                 read_only=False, arg_mapping=None):
     """
     Create a Django form from a Parameterized object.
 
@@ -248,7 +248,7 @@ def generate_django_form_xmstool(xms_tool_class, form_values, session, resource=
                     package, p_class = arg_atts['resource_class'].rsplit('.', 1)
                     mod = __import__(package, fromlist=[p_class])
                     resource_class = getattr(mod, p_class)
-                    
+
                     # Query on the resource, find the correct resource, and then look for the right arguments
                     resources = session.query(resource_class).all()
                     for r in resources:

--- a/tethysext/atcore/models/resource_workflow_steps/__init__.py
+++ b/tethysext/atcore/models/resource_workflow_steps/__init__.py
@@ -14,3 +14,4 @@ from tethysext.atcore.models.resource_workflow_steps.spatial_attributes_rws impo
 from tethysext.atcore.models.resource_workflow_steps.spatial_dataset_rws import SpatialDatasetRWS  # noqa: F401, E501
 from tethysext.atcore.models.resource_workflow_steps.spatial_condor_job_rws import SpatialCondorJobRWS  # noqa: F401, E501
 from tethysext.atcore.models.resource_workflow_steps.form_input_rws import FormInputRWS  # noqa: F401, E501
+from tethysext.atcore.models.resource_workflow_steps.xms_tool_rws import XMSToolRWS  # noqa: F401, E501

--- a/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
@@ -1,0 +1,53 @@
+"""
+********************************************************************************
+* Name: xms_tool_rws.py
+* Author: glarsen, mlebaron
+* Created On: October 17, 2019
+* Copyright: (c) Aquaveo 2019
+********************************************************************************
+"""
+from tethysext.atcore.models.app_users import ResourceWorkflowStep
+
+
+class XMSToolRWS(ResourceWorkflowStep):
+    """
+    Workflow step that can be used to get XMSTool input from a user.
+
+    Options:
+        form_title(str): Title to be displayed at the top of the form. Defaults to the name of the step.
+        status_label(str): Custom label for the status select form field. Defaults to "Status".
+        xmstool_class(dict): xms tool class used on the form.
+        renderer(str): Renderer option. Available values are 'django' and 'bokeh'. Defauls to 'django'. 
+    """  # noqa: #501
+
+    CONTROLLER = 'tethysext.atcore.controllers.resource_workflows.workflow_views.XMSToolWV'
+    TYPE = 'xms_tool_resource_workflow_step'
+
+    __mapper_args__ = {
+        'polymorphic_identity': TYPE
+    }
+
+    @property
+    def default_options(self):
+        default_options = super().default_options
+        default_options.update({
+            'form_title': None,
+            'status_label': None,
+            'xmstool_class': {},
+            'renderer': 'django'
+        })
+        return default_options
+
+    def init_parameters(self, *args, **kwargs):
+        return {
+            'form-values': {
+                'help': 'Values from form',
+                'value': {},
+                'required': True
+            },
+            'resource_name': {
+                'help': 'The name of the resource',
+                'value': '',
+                'required': True
+            }
+        }

--- a/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
@@ -13,10 +13,24 @@ class XMSToolRWS(ResourceWorkflowStep):
     """
     Workflow step that can be used to get XMSTool input from a user.
 
+    Example argument mapping (provide options from the database, for input arguments):
+    (Look in Project.datasets, where a dataset_type is a raster, for the dataset description, which is then filtered)
+    'arg_mapping': {
+        'input_raster': {
+            'resource_class': 'my_project.resources.project.Project',
+            'source_attr': 'datasets',
+            'attr': 'dataset_type',
+            'valid_values': ['RASTER_ASCII', 'RASTER_GEOTIFF'],
+            'name_attr': 'description',
+            'name_attr_regex': r'"(.*?[^\\])"',
+        },
+    }
+
     Options:
         form_title(str): Title to be displayed at the top of the form. Defaults to the name of the step.
         status_label(str): Custom label for the status select form field. Defaults to "Status".
         xmstool_class(dict): xms tool class used on the form.
+        arg_mapping(dict): dict of lookup options to map arguments to existing data.
         renderer(str): Renderer option. Available values are 'django' and 'bokeh'. Defauls to 'django'. 
     """  # noqa: #501
 
@@ -34,6 +48,7 @@ class XMSToolRWS(ResourceWorkflowStep):
             'form_title': None,
             'status_label': None,
             'xmstool_class': {},
+            'arg_mapping': {},
             'renderer': 'django'
         })
         return default_options

--- a/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
@@ -14,15 +14,14 @@ class XMSToolRWS(ResourceWorkflowStep):
     Workflow step that can be used to get XMSTool input from a user.
 
     Example argument mapping (provide options from the database, for input arguments):
-    (Look in Project.datasets, where a dataset_type is a raster, for the dataset description, which is then filtered)
+    (Look in resource.datasets, where a dataset_type is a raster, for the dataset description, which is then filtered)
     'arg_mapping': {
         'input_raster': {
-            'resource_class': 'my_project.resources.project.Project',
-            'source_attr': 'datasets',
-            'attr': 'dataset_type',
+            'resource_attr': 'datasets',
+            'filter_attr': 'dataset_type',
             'valid_values': ['RASTER_ASCII', 'RASTER_GEOTIFF'],
             'name_attr': 'description',
-            'name_attr_regex': r'"(.*?[^\\])"',
+            'name_attr_regex': r'"(.*?[^\\])"',  # optional regex expression on the name_attr value
         },
     }
 

--- a/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/xms_tool_rws.py
@@ -1,9 +1,9 @@
 """
 ********************************************************************************
 * Name: xms_tool_rws.py
-* Author: glarsen, mlebaron
-* Created On: October 17, 2019
-* Copyright: (c) Aquaveo 2019
+* Author: dgallup
+* Created On: December, 2023
+* Copyright: (c) Aquaveo 2023
 ********************************************************************************
 """
 from tethysext.atcore.models.app_users import ResourceWorkflowStep

--- a/tethysext/atcore/tests/integrated_tests/__init__.py
+++ b/tethysext/atcore/tests/integrated_tests/__init__.py
@@ -25,6 +25,7 @@ from .controllers.resource_view_tests import ResourceViewTests  # noqa: F401
 from .controllers.resource_workflows.workflow_view_mixins_tests import WorkflowViewMixinTests  # noqa: F401
 from .controllers.resource_workflows.result_view_mixins_tests import ResultViewMixinTests  # noqa: F401
 from .controllers.resource_workflows.workflow_views.form_input_wv_tests import FormInputWVTests  # noqa: F401
+from .controllers.resource_workflows.workflow_views.xms_tool_wv_tests import XmsToolWVTests  # noqa: F401
 from .controllers.resource_workflows.map_workflows.map_workflow_view_tests import MapWorkflowViewTests  # noqa: F401
 from .controllers.resource_workflows.map_workflows.spatial_condor_job_mwv_tests import SpatialCondorJobMwvTests  # noqa: F401, E501
 from .controllers.resource_workflows.map_workflows.spatial_data_mwv_tests import SpatialDataMwvTests  # noqa: F401

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
@@ -1,0 +1,258 @@
+from unittest import mock
+
+import param
+from django.http import HttpRequest
+from typing import Any, Optional
+from dataclasses import dataclass
+
+from tethysext.atcore.controllers.resource_workflows.workflow_view import ResourceWorkflowView
+from tethysext.atcore.models.app_users.resource_workflow import ResourceWorkflow
+from tethysext.atcore.tests.factories.django_user import UserFactory
+from django.test import RequestFactory
+from tethysext.atcore.services.app_users.roles import Roles
+# from tethysext.atcore.services.model_database import ModelDatabase
+from tethysext.atcore.models.app_users import AppUser, Resource
+from tethysext.atcore.models.resource_workflow_steps import XMSToolRWS
+from tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.workflow_view_test_case import \
+    WorkflowViewTestCase
+from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
+    tear_down_module_for_sqlalchemy_tests
+from tethysext.atcore.controllers.resource_workflows.workflow_views import generate_django_form_xmstool, XMSToolWV
+
+
+@dataclass
+class Parameter:
+    """Argument data for UI."""
+    type: str
+    label: str
+    default: Any
+    precedence: int
+    objects: Optional[list[str]] = None
+    doc: Optional[str] = None
+    default_suffix: str = None
+    _value: Any = None
+    table_definition: Any = None
+
+
+class TestTool(param.Parameterized):
+    int_value = param.Integer()
+    string_value = param.String()
+
+    def __init__(self, request=None, session=None, resource=None):
+        self.request = request
+        self.session = session
+        self.resource = resource
+
+    def initial_arguments(self):
+        arguments = []
+
+        argument1 = mock.MagicMock(name='name', description='description', type='integer', value=1,
+                                   io_direction=1, precedence=1)
+        argument1.get_param.return_value = Parameter(type='Integer', label='description', default=1, precedence=1,
+                                                     objects=None, doc='Arg 1', default_suffix=None, _value=None,
+                                                     table_definition=None)
+        arguments.append(argument1)
+
+        argument2 = mock.MagicMock(name='foo', description='bar', type='float', value=2.0,
+                                   io_direction=1, precedence=1)
+        argument2.get_param.return_value = Parameter(type='Number', label='bar', default=2.0, precedence=2,
+                                                     objects=None, doc='Arg 2', default_suffix=None, _value=None,
+                                                     table_definition=None)
+        arguments.append(argument2)
+
+        argument3 = mock.MagicMock(name='bar', description='output', type='string', value='3',
+                                   io_direction=2, precedence=3)
+        argument3.get_param.return_value = Parameter(type='String', label='description', default='3', precedence=3,
+                                                     objects=None, doc='Arg 3', default_suffix=None, _value=None,
+                                                     table_definition=None)
+        arguments.append(argument3)
+
+        return arguments
+
+
+def setUpModule():
+    setup_module_for_sqlalchemy_tests()
+
+
+def tearDownModule():
+    tear_down_module_for_sqlalchemy_tests()
+
+
+class XmsToolWVTests(WorkflowViewTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.request = mock.MagicMock(spec=HttpRequest)
+        self.request.namespace = 'my_namespace'
+        self.request.path = 'apps/and/such'
+
+        # xms_tool_class = mock.MagicMock()
+
+        self.context = {}
+
+        self.test_basic_tool = TestTool()
+        form_values = {
+            'name': {'name': 1},
+            'foo': {'foo': 2.0},
+            'bar': {'bar': '3'},
+        }
+        self.test_basic_form_from_param = generate_django_form_xmstool(self.test_basic_tool, form_values)
+        self.xrws = XMSToolRWS(
+            name='xrws',
+            help='basic xmstool input step',
+            order=1,
+            options={
+                'xmstool_class': 'tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.'
+                                 'workflow_views.xms_tool_wv_tests.TestTool'
+            }
+        )
+
+        self.workflow.steps.append(self.xrws)
+
+        self.django_user = UserFactory()
+        self.django_user.is_staff = True
+        self.django_user.is_superuser = True
+        self.django_user.save()
+
+        self.app_user = AppUser(
+            username=self.django_user.username,
+            role=Roles.ORG_ADMIN,
+            is_active=True,
+        )
+
+        self.request.user = self.app_user
+
+        self.session.add(self.workflow)
+        self.session.add(self.app_user)
+        self.session.commit()
+        self.request_factory = RequestFactory()
+
+        # Patch ResourceWorkflowView.user_has_active_role
+        uhar_patcher = mock.patch.object(ResourceWorkflowView, 'user_has_active_role', return_value=True)
+        self.mock_uhar = uhar_patcher.start()
+        self.addCleanup(uhar_patcher.stop)
+
+        # Patch ResourceWorkflowView.process_step_data
+        psd_patcher = mock.patch.object(ResourceWorkflowView, 'process_step_data')
+        self.mock_psd = psd_patcher.start()
+        self.addCleanup(psd_patcher.stop)
+
+    def tearDown(self):
+        super().tearDown()
+
+    @mock.patch.object(ResourceWorkflow, 'is_locked_for_request_user', return_value=False)
+    @mock.patch.object(Resource, 'is_locked_for_request_user', return_value=False)
+    def test_process_step_options_basic(self, _, __):
+        request = self.request_factory.get('/foo/bar/form-input')
+        request.user = self.django_user
+
+        mock_resource = mock.MagicMock(spec=Resource)
+        mock_context = {}
+
+        ret = XMSToolWV().process_step_options(
+            request=request,
+            session=self.session,
+            context=mock_context,
+            resource=mock_resource,
+            current_step=self.xrws,
+            previous_step=None,
+            next_step=None
+        )
+
+        self.assertIsNone(ret)
+        self.assertIn('form', mock_context)
+
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.workflow_views.xms_tool_wv.generate_django_form_xmstool')  # noqa: E501
+    def test_process_step_data_basic(self, mock_gen_form):
+        data = {
+            'param-form-integer_val': '1',
+            'param-form-float_val': '2.0',
+            'param-form-string_val': '3',
+        }
+        mock_gen_form()().is_valid.return_value = True
+        mock_gen_form()().cleaned_data = data
+        mock_session = mock.MagicMock()
+
+        current_url = '/foo/bar/set-status'
+        next_url = '/foo/bar/set-status/next'
+        previous_url = '/foo/bar/set-status/previous'
+        request = self.request_factory.post('/foo/bar/form-input', data=data)
+        request.user = self.django_user
+
+        mock_resource = mock.MagicMock()
+
+        ret = XMSToolWV().process_step_data(
+            request=request,
+            session=mock_session,
+            step=self.xrws,
+            resource=mock_resource,
+            current_url=current_url,
+            next_url=next_url,
+            previous_url=previous_url
+        )
+
+        self.assertEqual(self.mock_psd(), ret)
+        step = self.session.query(XMSToolRWS).filter(XMSToolRWS.name == 'xrws').one()
+        self.assertEqual({'value': {'integer_val': '1', 'float_val': '2.0', 'string_val': '3'}},
+                         step.get_parameter('form-values'))
+
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.workflow_views.xms_tool_wv.generate_django_form_xmstool')  # noqa: E501
+    def test_process_step_data_assert_is_valid(self, mock_gen_form):
+        data = {
+            'param-form-integer_val': '1',
+            'param-form-float_val': '2.0',
+            'param-form-string_val': 'string',
+        }
+        mock_gen_form()().is_valid.return_value = False
+        mock_session = mock.MagicMock()
+
+        current_url = '/foo/bar/set-status'
+        next_url = '/foo/bar/set-status/next'
+        previous_url = '/foo/bar/set-status/previous'
+        request = self.request_factory.post('/foo/bar/form-input', data=data)
+        request.user = self.django_user
+
+        mock_resource = mock.MagicMock()
+
+        with self.assertRaises(RuntimeError) as cm:
+            _ = XMSToolWV().process_step_data(
+                request=request,
+                session=mock_session,
+                step=self.xrws,
+                resource=mock_resource,
+                current_url=current_url,
+                next_url=next_url,
+                previous_url=previous_url
+            )
+        self.assertEqual('form is invalid', str(cm.exception))
+
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.workflow_views.xms_tool_wv.generate_django_form_xmstool')  # noqa: E501
+    def test_process_step_data_assert_param_data(self, mock_gen_form):
+        data = {
+            'param-form-integer_val': '1',
+            'param-form-float_val': '2.0',
+            'param-form-string_val': 'string',
+        }
+        mock_gen_form()().is_valid.return_value = True
+        mock_gen_form()().cleaned_data.__getitem__.side_effect = ValueError('foo_cd')
+        mock_session = mock.MagicMock()
+
+        current_url = '/foo/bar/set-status'
+        next_url = '/foo/bar/set-status/next'
+        previous_url = '/foo/bar/set-status/previous'
+        request = self.request_factory.post('/foo/bar/form-input', data=data)
+        request.user = self.django_user
+
+        mock_resource = mock.MagicMock()
+
+        with self.assertRaises(RuntimeError) as cm:
+            _ = XMSToolWV().process_step_data(
+                request=request,
+                session=mock_session,
+                step=self.xrws,
+                resource=mock_resource,
+                current_url=current_url,
+                next_url=next_url,
+                previous_url=previous_url
+            )
+        self.assertEqual('error setting param data: foo_cd', str(cm.exception))

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
@@ -96,14 +96,14 @@ class XmsToolWVTests(WorkflowViewTestCase):
             'foo': {'foo': 2.0},
             'bar': {'bar': '3'},
         }
-        self.test_basic_form_from_param = generate_django_form_xmstool(self.test_basic_tool, form_values)
+        self.test_basic_form_from_param = generate_django_form_xmstool(self.test_basic_tool, form_values, None)
         self.xrws = XMSToolRWS(
             name='xrws',
             help='basic xmstool input step',
             order=1,
             options={
                 'xmstool_class': 'tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.'
-                                 'workflow_views.xms_tool_wv_tests.TestTool'
+                                 'workflow_views.xms_tool_wv_tests.TestTool',
             }
         )
 

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
@@ -307,5 +307,8 @@ class XmsToolWVTests(WorkflowViewTestCase):
                 'name_attr_regex': r'"(.*?[^\\])"',
             },
         }
-        generate_django_form_xmstool(xmstool_class, {}, mock_session, resource=mock_resource, arg_mapping=arg_mapping,
-                                     setup_func=mock_setup_func)
+        form = generate_django_form_xmstool(xmstool_class, {}, mock_session, resource=mock_resource,
+                                            arg_mapping=arg_mapping, setup_func=mock_setup_func)
+        self.assertTrue('name' in form.base_fields)
+        self.assertTrue('foo' in form.base_fields)
+        self.assertTrue('bar' in form.base_fields)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/workflow_views/xms_tool_wv_tests.py
@@ -112,7 +112,7 @@ class XmsToolWVTests(WorkflowViewTestCase):
             'foo': {'foo': 2.0},
             'bar': {'bar': '3'},
         }
-        self.test_basic_form_from_param = generate_django_form_xmstool(self.test_basic_tool, form_values, None)
+        self.test_basic_form_from_param = generate_django_form_xmstool(self.test_basic_tool, form_values)
         self.xrws = XMSToolRWS(
             name='xrws',
             help='basic xmstool input step',
@@ -297,23 +297,19 @@ class XmsToolWVTests(WorkflowViewTestCase):
         mock_dataset.objects = ['d']
         mock_resource = mock.MagicMock()
         mock_resource.datasets = [mock_dataset, mock_dataset2]
-        mock_session = mock.MagicMock()
-        mock_session.query().all.return_value = [mock_resource]
 
         xmstool_class = TestTool()
         arg_mapping = {
             'bar': {
-                'resource_class': 'tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.'
-                                  'workflow_views.xms_tool_wv_tests.TestResource',
-                'source_attr': 'datasets',
-                'attr':  'dataset_type',
+                'resource_attr': 'datasets',
+                'filter_attr': 'dataset_type',
                 'valid_values': ['ObjectSelector'],
                 'name_attr': 'description',
                 'name_attr_regex': r'"(.*?[^\\])"',
             },
         }
 
-        form = generate_django_form_xmstool(xmstool_class, {}, mock_session, resource=mock_resource,
+        form = generate_django_form_xmstool(xmstool_class, {}, resource=mock_resource,
                                             arg_mapping=arg_mapping, setup_func=mock_setup_func)
 
         self.assertTrue('name' in form.base_fields)

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
@@ -246,7 +246,7 @@ class ResourceWorkflowBaseMethodsTests(SqlAlchemyTestCase):
         mock_get_parameter.return_value = {'existing_data': 'data_value'}
         ret = self.step_2.workflow.get_tabular_data_for_previous_steps(self.step_2, request, session, resource)
 
-        expected_result = {'foo': {'Existing Data': 'data_name'}}
+        expected_result = {'foo': {'Existing Data': 'data_value'}}
         self.assertEqual(expected_result, ret)
 
     @mock.patch('tethysext.atcore.models.resource_workflow_steps.form_input_rws.FormInputRWS.get_parameter')

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
@@ -246,7 +246,7 @@ class ResourceWorkflowBaseMethodsTests(SqlAlchemyTestCase):
         mock_get_parameter.return_value = {'existing_data': 'data_value'}
         ret = self.step_2.workflow.get_tabular_data_for_previous_steps(self.step_2, request, session, resource)
 
-        expected_result = {'foo': {'Existing Data': 'data_value'}}
+        expected_result = {'foo': {'Existing Data': 'data_name'}}
         self.assertEqual(expected_result, ret)
 
     @mock.patch('tethysext.atcore.models.resource_workflow_steps.form_input_rws.FormInputRWS.get_parameter')


### PR DESCRIPTION
Primary changes in this Pull Request:
Added a new XMS tool ResourceWorkflowStep.  When an xmstool_class is specified, it will appear as a form on a ResourceWorkflowView with the different tool parameters.

Ex:
xmstool_step = XMSToolRWS(
    name='XMS Tool',
    order=10,
    help='Run the xmsool',
    options={
        'xmstool_class': 'xms.tool.some_tool',
        'form_title': 'XMS tool',
        'renderer': 'django',
    }
)
- 

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

