### PR TITLE
Serialization Mixin

### DIFF
--- a/.github/workflows/push_on_commits_wo_tag.yml
+++ b/.github/workflows/push_on_commits_wo_tag.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         echo $TAG
     - name: build and push tag
-      uses: aevea/action-kaniko@v0.10.0
+      uses: aevea/action-kaniko@v0.12.0
       with:
         # Docker registry where the image will be pushed
         registry: docker.io

--- a/.github/workflows/push_on_tag.yml
+++ b/.github/workflows/push_on_tag.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         echo $TAG
     - name: build and push tag
-      uses: aevea/action-kaniko@v0.10.0
+      uses: aevea/action-kaniko@v0.12.0
       with:
         # Docker registry where the image will be pushed
         registry: docker.io
@@ -48,7 +48,7 @@ jobs:
         # Dockerfile filename
         build_file: Dockerfile
     - name: build and push latest
-      uses: aevea/action-kaniko@v0.10.0
+      uses: aevea/action-kaniko@v0.12.0
       with:
         # Docker registry where the image will be pushed
         registry: docker.io

--- a/tethysext/atcore/controllers/app_users/mixins.py
+++ b/tethysext/atcore/controllers/app_users/mixins.py
@@ -76,8 +76,9 @@ class ResourceBackUrlViewMixin(AppUsersViewMixin):
         # Default to the resource details page
         if not self.back_url:
             self.back_url = self.default_back_url(
+                *args,
                 request=request,
-                *args, **kwargs
+                **kwargs
             )
         return super().dispatch(request, *args, **kwargs)
 

--- a/tethysext/atcore/controllers/map_view.py
+++ b/tethysext/atcore/controllers/map_view.py
@@ -78,17 +78,19 @@ class MapView(ResourceView):
 
         # Get Managers Hook
         map_manager = self.get_map_manager(
+            *args,
             request=request,
             resource=resource,
-            *args, **kwargs
+            **kwargs
         )
 
         # Render the Map
         map_view, model_extent, layer_groups = map_manager.compose_map(
+            *args,
             request=request,
             resource_id=resource_id,
             scenario_id=scenario_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Tweak map settings
@@ -308,9 +310,10 @@ class MapView(ResourceView):
         """
         # Get Managers Hook
         map_manager = self.get_map_manager(
+            *args,
             request=request,
             resource=resource,
-            *args, **kwargs
+            **kwargs
         )
         legend_div_id = json.loads(request.POST.get('div_id'))
         minimum = json.loads(request.POST.get('minimum'))
@@ -357,9 +360,10 @@ class MapView(ResourceView):
         """
         # Get Managers Hook
         map_manager = self.get_map_manager(
+            *args,
             request=request,
             resource=resource,
-            *args, **kwargs
+            **kwargs
         )
         status = request.POST.get('status', 'create')
         layer_group_name = request.POST.get('layer_group_name')

--- a/tethysext/atcore/controllers/resource_view.py
+++ b/tethysext/atcore/controllers/resource_view.py
@@ -74,11 +74,12 @@ class ResourceView(ResourceViewMixin):
 
         # Context hook
         context = self.get_context(
+            *args,
             request=request,
             session=session,
             context=context,
             resource=resource,
-            *args, **kwargs
+            **kwargs
         )
 
         # Default Permissions
@@ -86,10 +87,11 @@ class ResourceView(ResourceViewMixin):
 
         # Permissions hook
         permissions = self.get_permissions(
+            *args,
             request=request,
             permissions=permissions,
             resource=resource,
-            *args, **kwargs
+            **kwargs
         )
 
         context.update(permissions)

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/map_workflow_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/map_workflow_view.py
@@ -40,25 +40,27 @@ class MapWorkflowView(MapView, ResourceWorkflowView):
             dict: modified context dictionary.
         """  # noqa: E501
         map_context = MapView.get_context(
-            self=self,
+            self,
+            *args,
             request=request,
             session=session,
             resource=resource,
             context=context,
             workflow_id=workflow_id,
             step_id=step_id,
-            *args, **kwargs
+            **kwargs
         )
 
         workflow_context = ResourceWorkflowView.get_context(
-            self=self,
+            self,
+            *args,
             request=request,
             session=session,
             resource=resource,
             context=context,
             workflow_id=workflow_id,
             step_id=step_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Combine contexts

--- a/tethysext/atcore/controllers/resource_workflows/resource_workflow_router.py
+++ b/tethysext/atcore/controllers/resource_workflows/resource_workflow_router.py
@@ -166,21 +166,23 @@ class ResourceWorkflowRouter(WorkflowViewMixin):
         """
         if result_id:
             response = self._route_to_result_controller(
+                *args,
                 request=request,
                 resource_id=resource_id,
                 workflow_id=workflow_id,
                 step_id=step_id,
                 result_id=result_id,
-                *args, **kwargs
+                **kwargs
             )
 
         else:
             response = self._route_to_step_controller(
+                *args,
                 request=request,
                 resource_id=resource_id,
                 workflow_id=workflow_id,
                 step_id=step_id,
-                *args, **kwargs
+                **kwargs
             )
         return response
 

--- a/tethysext/atcore/controllers/resource_workflows/results_views/dataset_workflow_results_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/results_views/dataset_workflow_results_view.py
@@ -42,6 +42,7 @@ class DatasetWorkflowResultView(WorkflowResultsView):
             dict: modified context dictionary.
         """  # noqa: E501
         base_context = super().get_context(
+            *args,
             request=request,
             session=session,
             resource=resource,
@@ -49,7 +50,7 @@ class DatasetWorkflowResultView(WorkflowResultsView):
             workflow_id=workflow_id,
             step_id=step_id,
             result_id=result_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Get the result

--- a/tethysext/atcore/controllers/resource_workflows/results_views/map_workflow_results_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/results_views/map_workflow_results_view.py
@@ -42,13 +42,14 @@ class MapWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
             dict: modified context dictionary.
         """  # noqa: E501
         base_context = super(MapWorkflowView, self).get_context(
+            *args,
             request=request,
             session=session,
             resource=resource,
             context=context,
             workflow_id=workflow_id,
             step_id=step_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # TODO: Look at why this approach does not work. The tab underneath the map does not show up.
@@ -64,6 +65,7 @@ class MapWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
         # )
         result_workflow_context = WorkflowResultsView.get_context(
             self,
+            *args,
             request=request,
             session=session,
             resource=resource,
@@ -71,7 +73,7 @@ class MapWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
             workflow_id=workflow_id,
             step_id=step_id,
             result_id=result_id,
-            *args, **kwargs
+            **kwargs
         )
         # Combine contexts
         base_context.update(result_workflow_context)

--- a/tethysext/atcore/controllers/resource_workflows/results_views/plot_workflow_results_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/results_views/plot_workflow_results_view.py
@@ -40,6 +40,7 @@ class PlotWorkflowResultView(WorkflowResultsView):
             dict: modified context dictionary.
         """  # noqa: E501
         base_context = super().get_context(
+            *args,
             request=request,
             session=session,
             resource=resource,
@@ -47,7 +48,7 @@ class PlotWorkflowResultView(WorkflowResultsView):
             workflow_id=workflow_id,
             step_id=step_id,
             result_id=result_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Get the result

--- a/tethysext/atcore/controllers/resource_workflows/results_views/report_workflow_results_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/results_views/report_workflow_results_view.py
@@ -166,17 +166,19 @@ class ReportWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
 
         base_context = MapWorkflowView.get_context(
             self,
+            *args,
             request=request,
             session=session,
             resource=resource,
             context=context,
             workflow_id=workflow_id,
             step_id=step_id,
-            *args, **kwargs
+            **kwargs
         )
 
         result_workflow_context = WorkflowResultsView.get_context(
             self,
+            *args,
             request=request,
             session=session,
             resource=resource,
@@ -184,7 +186,7 @@ class ReportWorkflowResultsView(MapWorkflowView, WorkflowResultsView):
             workflow_id=workflow_id,
             step_id=step_id,
             result_id=result_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Combine contexts

--- a/tethysext/atcore/controllers/resource_workflows/workflow_results_view.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_results_view.py
@@ -37,13 +37,14 @@ class WorkflowResultsView(ResourceWorkflowView, ResultViewMixin):
 
         # Call super class get_context first
         context = super().get_context(
+            *args,
             request=request,
             session=session,
             resource=resource,
             context=context,
             workflow_id=workflow_id,
             step_id=step_id,
-            *args, **kwargs
+            **kwargs
         )
 
         # Validate the result

--- a/tethysext/atcore/controllers/resources/tabbed_resource_details.py
+++ b/tethysext/atcore/controllers/resources/tabbed_resource_details.py
@@ -57,19 +57,21 @@ class TabbedResourceDetails(ResourceDetails):
         tab_action = request.GET.get('tab_action', None)
         if tab_action:
             return self._handle_tab_action_request(
+                *args,
                 request=request,
                 resource=resource,
                 session=session,
                 tab_slug=tab_slug,
                 tab_action=tab_action,
-                *args, **kwargs
+                **kwargs
             )
 
         tabs = self.get_tabs(
+            *args,
             request=request,
             resource=resource,
             tab_slug=tab_slug,
-            *args, **kwargs
+            **kwargs
         )
 
         # Build list of unique CSS and JS requirements
@@ -103,12 +105,13 @@ class TabbedResourceDetails(ResourceDetails):
         tab_action = request.POST.get('tab_action', None)
         if tab_action:
             return self._handle_tab_action_request(
+                *args,
                 request=request,
                 resource=resource,
                 session=session,
                 tab_slug=tab_slug,
                 tab_action=tab_action,
-                *args, **kwargs
+                **kwargs
             )
 
         return HttpResponseNotAllowed(['GET'])
@@ -123,12 +126,13 @@ class TabbedResourceDetails(ResourceDetails):
         tab_action = request.GET.get('tab_action', None)
         if tab_action:
             return self._handle_tab_action_request(
+                *args,
                 request=request,
                 resource=resource,
                 session=session,
                 tab_slug=tab_slug,
                 tab_action=tab_action,
-                *args, **kwargs
+                **kwargs
             )
 
         return HttpResponseNotAllowed(['GET'])
@@ -147,10 +151,11 @@ class TabbedResourceDetails(ResourceDetails):
             HttpResponse: Response to action request.
         """
         TabView = self.get_tab_view(
+            *args,
             request=request,
             resource=resource,
             tab_slug=tab_slug,
-            *args, **kwargs
+            **kwargs
         )
 
         if not TabView:
@@ -221,10 +226,11 @@ class TabbedResourceDetails(ResourceDetails):
             ResourceTabView: The ResourceTabView class or None if not found.
         """
         tabs = self.get_tabs(
+            *args,
             request=request,
             resource=resource,
             tab_slug=tab_slug,
-            *args, **kwargs
+            **kwargs
         )
 
         for tab in tabs:

--- a/tethysext/atcore/mixins/__init__.py
+++ b/tethysext/atcore/mixins/__init__.py
@@ -3,6 +3,7 @@ from tethysext.atcore.mixins.attributes_mixin import AttributesMixin  # noqa: F4
 from tethysext.atcore.mixins.options_mixin import OptionsMixin  # noqa: F401
 from tethysext.atcore.mixins.results_mixin import ResultsMixin  # noqa: F401
 from tethysext.atcore.mixins.user_lock_mixin import UserLockMixin  # noqa: F401
+from tethysext.atcore.mixins.serialize_mixin import SerializeMixin  # noqa: F401
 # DO NOT IMPORT FileCollectionMixin or FileCollectionsControllerMixin. CAUSES CIRCULAR IMPORT ISSUES.
 # from tethysext.atcore.mixins.file_collection_mixin import FileCollectionMixin  # noqa: F401
 # from tethysext.atcore.mixins.file_collection_controller_mixin import FileCollectionsControllerMixin  # noqa: F401

--- a/tethysext/atcore/mixins/serialize_mixin.py
+++ b/tethysext/atcore/mixins/serialize_mixin.py
@@ -36,7 +36,6 @@ class SerializeMixin:
 
         d = {
             'id': self.id,
-            'date_created': self.date_created,
             'name': self.name,
             'type': self.type,
         }

--- a/tethysext/atcore/mixins/serialize_mixin.py
+++ b/tethysext/atcore/mixins/serialize_mixin.py
@@ -33,7 +33,7 @@ class SerializeMixin:
             Serialized Resource dictionary.
         """
         from tethysext.atcore.mixins import UserLockMixin, AttributesMixin, StatusMixin
-        
+
         d = {
             'id': self.id,
             'date_created': self.date_created,

--- a/tethysext/atcore/mixins/serialize_mixin.py
+++ b/tethysext/atcore/mixins/serialize_mixin.py
@@ -4,6 +4,18 @@ from uuid import UUID
 
 
 class SerializeMixin:
+    def on_serialize(self, d: dict, format: str):
+        """Hook for subclasses to add additional serialization logic.
+
+        Args:
+            base: Base serialized Resource dictionary.
+            format: Format to serialize to. One of 'dict' or 'json'.
+
+        Returns:
+            dict: Serialized Resource.
+        """
+        return d
+
     def serialize_resource_props(self) -> dict:
         """Serialize the normal Resource properties into a dictionary.
 
@@ -44,3 +56,25 @@ class SerializeMixin:
             raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
 
         return json.dumps(d, default=json_default)
+
+    def serialize(self, format: str = 'dict'):
+        """Serialize this Resource.
+
+        Args:
+            format: Format to serialize to. One of 'dict' or 'json'.
+
+        Returns:
+            dict: Serialized Resource.
+        """
+        if format not in ['dict', 'json']:
+            raise ValueError(f'Invalid format: "{format}". Must be one of "dict" or "json".')
+        d = self.serialize_resource_props()
+        
+        # Call hook
+        d = self.on_serialize(d, format)
+
+        # Convert to json string if requested
+        if format == 'json':
+            return self.json_dumps(d)
+
+        return d

--- a/tethysext/atcore/mixins/serialize_mixin.py
+++ b/tethysext/atcore/mixins/serialize_mixin.py
@@ -37,7 +37,6 @@ class SerializeMixin:
         d = {
             'id': self.id,
             'date_created': self.date_created,
-            'description': self.description,
             'name': self.name,
             'type': self.type,
         }

--- a/tethysext/atcore/mixins/serialize_mixin.py
+++ b/tethysext/atcore/mixins/serialize_mixin.py
@@ -1,0 +1,46 @@
+import datetime
+import json
+from uuid import UUID
+
+
+class SerializeMixin:
+    def serialize_resource_props(self) -> dict:
+        """Serialize the normal Resource properties into a dictionary.
+
+        Returns:
+            Serialized Resource dictionary.
+        """
+        return {
+            'id': self.id,
+            'attributes': self.attributes,
+            'created_by': self.created_by,
+            'date_created': self.date_created,
+            'description': self.description,
+            'display_type_plural': self.DISPLAY_TYPE_PLURAL,
+            'display_type_singular': self.DISPLAY_TYPE_SINGULAR,
+            'locked': self.is_user_locked,
+            'name': self.name,
+            'organizations': [{
+                'id': org.id,
+                'name': org.name
+            } for org in self.organizations],
+            'public': self.public,
+            'slug': self.SLUG,
+            'status': self.get_status(),
+            'type': self.type,
+        }
+
+    def json_dumps(self, d: dict) -> str:
+        """Serialize this Resource to a json string.
+
+        Returns:
+            str: JSON string.
+        """
+        def json_default(obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.isoformat()
+            elif isinstance(obj, UUID):
+                return str(obj)
+            raise TypeError(f'Object of type {obj.__class__.__name__} is not JSON serializable')
+
+        return json.dumps(d, default=json_default)

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -6,7 +6,7 @@ from django.utils.functional import classproperty
 from sqlalchemy import Column, Boolean, DateTime, String
 from sqlalchemy.orm import relationship, backref
 from tethysext.atcore.models.types.guid import GUID
-from tethysext.atcore.mixins import StatusMixin, AttributesMixin, UserLockMixin
+from tethysext.atcore.mixins import StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin
 
 from .app_user import AppUsersBase
 from .associations import organization_resource_association, resource_parent_child_association
@@ -14,7 +14,7 @@ from .associations import organization_resource_association, resource_parent_chi
 __all__ = ['Resource']
 
 
-class Resource(StatusMixin, AttributesMixin, UserLockMixin, AppUsersBase):
+class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppUsersBase):
     """
     Definition for the resources table.
     """

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -73,6 +73,7 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
         """
         d.update({
             'created_by': self.created_by,
+            'date_created': self.date_created,
             'description': self.description,
             'display_type_plural': self.DISPLAY_TYPE_PLURAL,
             'display_type_singular': self.DISPLAY_TYPE_SINGULAR,

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -61,3 +61,26 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
     @classproperty
     def SLUG(self):
         return slugify(self.DISPLAY_TYPE_PLURAL.lower()).replace("-", "_")
+
+
+    def serialize_base_fields(self, d: dict) -> dict:
+        """Hook for ATCore base classes to add their custom fields to serialization.
+
+        Args:
+            d: Base serialized Resource dictionary.
+
+        Returns:
+            Serialized Resource dictionary.
+        """
+        d.update({
+            'created_by': self.created_by,
+            'display_type_plural': self.DISPLAY_TYPE_PLURAL,
+            'display_type_singular': self.DISPLAY_TYPE_SINGULAR,
+            'organizations': [{
+                'id': org.id,
+                'name': org.name
+            } for org in self.organizations],
+            'public': self.public,
+            'slug': self.SLUG,
+        })
+        return d

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -74,6 +74,7 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
         """
         d.update({
             'created_by': self.created_by,
+            'description': self.description,
             'display_type_plural': self.DISPLAY_TYPE_PLURAL,
             'display_type_singular': self.DISPLAY_TYPE_SINGULAR,
             'organizations': [{

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -62,7 +62,6 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
     def SLUG(self):
         return slugify(self.DISPLAY_TYPE_PLURAL.lower()).replace("-", "_")
 
-
     def serialize_base_fields(self, d: dict) -> dict:
         """Hook for ATCore base classes to add their custom fields to serialization.
 

--- a/tethysext/atcore/models/app_users/resource_workflow.py
+++ b/tethysext/atcore/models/app_users/resource_workflow.py
@@ -73,7 +73,6 @@ class ResourceWorkflow(AppUsersBase, AttributesMixin, ResultsMixin, UserLockMixi
     type = Column(String)
 
     name = Column(String)
-    description = Column(String)
     date_created = Column(DateTime, default=dt.datetime.utcnow)
     lock_when_finished = Column(Boolean, default=False)
     _attributes = Column(String)
@@ -284,7 +283,8 @@ class ResourceWorkflow(AppUsersBase, AttributesMixin, ResultsMixin, UserLockMixi
 
     def get_url(self):
         """Get the URL to the workflow. IMPORTANT: Must implement get_url_name()."""
-        return reverse(self.get_url_name(), kwargs={
+        n = self.get_url_name()
+        return reverse(n, kwargs={
             'resource_id': self.resource_id,
             'workflow_id': self.id,
         })

--- a/tethysext/atcore/models/app_users/resource_workflow.py
+++ b/tethysext/atcore/models/app_users/resource_workflow.py
@@ -20,7 +20,7 @@ from tethysext.atcore.models.types import GUID
 from tethysext.atcore.mixins import AttributesMixin, ResultsMixin, UserLockMixin, SerializeMixin
 from tethysext.atcore.models.app_users.base import AppUsersBase
 from tethysext.atcore.models.app_users import ResourceWorkflowStep
-from tethysext.atcore.models.resource_workflow_steps import FormInputRWS
+from tethysext.atcore.models.resource_workflow_steps import FormInputRWS, ResultsResourceWorkflowStep
 
 log = logging.getLogger(f'tethys.{__name__}')
 __all__ = ['ResourceWorkflow']
@@ -308,11 +308,17 @@ class ResourceWorkflow(AppUsersBase, AttributesMixin, ResultsMixin, UserLockMixi
         Returns:
             Serialized Resource dictionary.
         """
+        results = [r.serialize(format='dict') for r in self.results]
+        for step in self.steps:
+            if isinstance(step, ResultsResourceWorkflowStep):
+                results.extend([r.serialize(format='dict') for r in step.results])
+
         d.update({
             'created_by': self.creator.username if self.creator else None,
+            'date_created': self.date_created,
             'display_type_plural': self.DISPLAY_TYPE_PLURAL,
             'display_type_singular': self.DISPLAY_TYPE_SINGULAR,
-            'results': [result.serialize(format='dict') for result in self.results],
+            'results': results,
             'status': self.get_status(),
             'steps': [step.to_dict() for step in self.steps],
             'url': None,

--- a/tethysext/atcore/models/app_users/resource_workflow_result.py
+++ b/tethysext/atcore/models/app_users/resource_workflow_result.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy import Column, ForeignKey, String, PickleType, Integer
 from tethysext.atcore.models.types import GUID
-from tethysext.atcore.mixins import StatusMixin, AttributesMixin, OptionsMixin
+from tethysext.atcore.mixins import StatusMixin, AttributesMixin, OptionsMixin, SerializeMixin
 from tethysext.atcore.models.app_users.base import AppUsersBase
 from tethysext.atcore.models.controller_metadata import ControllerMetadata
 
@@ -19,7 +19,7 @@ from tethysext.atcore.models.controller_metadata import ControllerMetadata
 __all__ = ['ResourceWorkflowResult']
 
 
-class ResourceWorkflowResult(AppUsersBase, StatusMixin, AttributesMixin, OptionsMixin):
+class ResourceWorkflowResult(AppUsersBase, StatusMixin, AttributesMixin, OptionsMixin, SerializeMixin):
     """
     Data model for storing information about resource workflow results.
     """
@@ -91,3 +91,20 @@ class ResourceWorkflowResult(AppUsersBase, StatusMixin, AttributesMixin, Options
         Resets result to initial state.
         """
         self._data = dict()
+
+    def serialize_base_fields(self, d: dict) -> dict:
+        """Hook for ATCore base classes to add their custom fields to serialization.
+
+        Args:
+            d: Base serialized Resource dictionary.
+
+        Returns:
+            Serialized Resource dictionary.
+        """
+        d.update({
+            'codename': self.codename,
+            'data': self.data,
+            'options': self.options,
+            'order': self.order,
+        })
+        return d

--- a/tethysext/atcore/models/app_users/resource_workflow_result.py
+++ b/tethysext/atcore/models/app_users/resource_workflow_result.py
@@ -104,7 +104,6 @@ class ResourceWorkflowResult(AppUsersBase, StatusMixin, AttributesMixin, Options
         d.update({
             'codename': self.codename,
             'data': self.data,
-            'options': self.options,
             'order': self.order,
         })
         return d

--- a/tethysext/atcore/models/app_users/resource_workflow_step.py
+++ b/tethysext/atcore/models/app_users/resource_workflow_step.py
@@ -18,7 +18,7 @@ from tethysext.atcore.mixins import StatusMixin, AttributesMixin, OptionsMixin
 from tethysext.atcore.models.app_users.base import AppUsersBase
 from tethysext.atcore.models.app_users.associations import step_parent_child_association
 from tethysext.atcore.models.controller_metadata import ControllerMetadata
-
+from tethysext.atcore.utilities import json_serializer
 
 __all__ = ['ResourceWorkflowStep']
 
@@ -223,7 +223,7 @@ class ResourceWorkflowStep(AppUsersBase, StatusMixin, AttributesMixin, OptionsMi
         Returns:
             str: JSON string representation of ResourceWorkflowStep.
         """
-        return json.dumps(self.to_dict())
+        return json.dumps(self.to_dict(), default=json_serializer)
 
     def validate(self):
         """

--- a/tethysext/atcore/tests/integrated_tests/__init__.py
+++ b/tethysext/atcore/tests/integrated_tests/__init__.py
@@ -46,7 +46,7 @@ from .mixins.attributes_mixin import AttributesMixinTests  # noqa: F401
 from .mixins.file_collection_mixin_tests import FileCollectionMixinTests  # noqa: F401
 from .mixins.user_lock_mixin_tests import UserLockMixinTests  # noqa: F401
 from .mixins.file_collections_controller_mixin_tests import FileCollectionsControllerMixinTests  # noqa: F401
-from .mixins.serialize_mixin_tests import SerializeMixinResourceTests  # noqa: F401
+from .mixins.serialize_mixin_tests import SerializeMixinResourceTests, SerializeMixinResourceWorkflowTests  # noqa: F401
 from .models.app_users.app_user_organization_tests import AppUserOrganizationTests  # noqa: F401
 from .models.app_users.app_user_tests import AppUserTests  # noqa: F401
 from .models.app_users.resource_workflow_result_tests import ResourceWorkflowResultTests  # noqa: F401

--- a/tethysext/atcore/tests/integrated_tests/__init__.py
+++ b/tethysext/atcore/tests/integrated_tests/__init__.py
@@ -46,6 +46,7 @@ from .mixins.attributes_mixin import AttributesMixinTests  # noqa: F401
 from .mixins.file_collection_mixin_tests import FileCollectionMixinTests  # noqa: F401
 from .mixins.user_lock_mixin_tests import UserLockMixinTests  # noqa: F401
 from .mixins.file_collections_controller_mixin_tests import FileCollectionsControllerMixinTests  # noqa: F401
+from .mixins.serialize_mixin_tests import SerializeMixinResourceTests  # noqa: F401
 from .models.app_users.app_user_organization_tests import AppUserOrganizationTests  # noqa: F401
 from .models.app_users.app_user_tests import AppUserTests  # noqa: F401
 from .models.app_users.resource_workflow_result_tests import ResourceWorkflowResultTests  # noqa: F401

--- a/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
@@ -1,0 +1,100 @@
+import json
+import uuid
+import datetime as dt
+from tethysext.atcore.models.app_users import Resource
+from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
+from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
+    tear_down_module_for_sqlalchemy_tests
+
+
+def setUpModule():
+    setup_module_for_sqlalchemy_tests()
+
+
+def tearDownModule():
+    tear_down_module_for_sqlalchemy_tests()
+
+
+class CustomResource(Resource):
+    TYPE = 'custom_resource'
+    DISPLAY_TYPE_SINGULAR = 'Custom'
+    DISPLAY_TYPE_PLURAL = 'Customs'
+    __mapper_args__ = {
+        'polymorphic_identity': TYPE,
+    }
+    some_field = 'bar'
+    some_date = dt.datetime(2024, 4, 8)
+    some_id = uuid.uuid4()
+
+    def serialize_custom_fields(self, d: dict):
+        d.update(
+            {
+                'some_field': self.some_field,
+                'some_date': self.some_date,
+                'some_id': self.some_id,
+            }
+        )
+        return d
+
+
+class SerializeMixinTests(SqlAlchemyTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.instance = Resource(
+            name='Test Resource',
+            description='A test resource',
+            created_by='test_user',
+        )
+        self.instance.set_status(Resource.STATUS_AVAILABLE)
+        self.instance.set_attribute('some_attr', 'baz')
+
+    def tearDown(self):
+        super().tearDown()
+
+    def verify_resource_fields(self, d, format='dict'):
+        if format == 'json':
+            d = json.loads(d)
+
+        # Verify base fields
+        self.assertEqual(d['id'], self.instance.id)
+        if format == 'json':
+            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
+        else:
+            self.assertEqual(d['date_created'], self.instance.date_created)
+        self.assertEqual(d['name'], self.instance.name)
+        self.assertEqual(d['type'], self.instance.type)
+
+        # Verify Resource fields
+        self.assertEqual(d['description'], self.instance.description)
+        self.assertEqual(d['locked'], self.instance.is_user_locked)
+        self.assertEqual(d['status'], self.instance.get_status())
+        self.assertDictEqual(d['attributes'], self.instance.attributes)
+        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
+        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
+        self.assertEqual(d['slug'], self.instance.SLUG)
+
+        # Verify custom fields
+        self.assertEqual(d['some_field'], self.instance.some_field)
+        if format == 'json':
+            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
+        else:
+            self.assertEqual(d['some_date'], self.instance.some_date)
+        if format == 'json':
+            self.assertEqual(d['some_id'], str(self.instance.some_id))
+        else:
+            self.assertEqual(d['some_id'], self.instance.some_id)
+
+    def test_resource_serialize_dict(self):
+        s_dict = self.instance.serialize()
+        self.assertIsInstance(s_dict, dict)
+        self.verify_resource_fields(s_dict, format='dict')
+
+    def test_resource_serialize_json(self):
+        s_json = self.instance.serialize(format='json')
+        self.assertIsInstance(s_json, str)
+        self.verify_resource_fields(s_json, format='json')
+
+    def test_resource_serialize_invalid_format(self):
+        with self.assertRaises(ValueError):
+            self.instance.serialize(format='invalid_format')

--- a/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
@@ -1,7 +1,12 @@
 import json
 import uuid
 import datetime as dt
-from tethysext.atcore.models.app_users import Resource, ResourceWorkflow, ResourceWorkflowResult, ResourceWorkflowStep
+from unittest import mock
+from tethysext.atcore.models.app_users import Organization, Resource, ResourceWorkflow
+from tethysext.atcore.models.resource_workflow_steps import SpatialInputRWS, ResultsResourceWorkflowStep
+from tethysext.atcore.models.resource_workflow_results import SpatialWorkflowResult
+from tethysext.atcore.services.map_manager import MapManagerBase
+from tethysext.atcore.services.base_spatial_manager import BaseSpatialManager
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
     tear_down_module_for_sqlalchemy_tests
@@ -16,9 +21,59 @@ def tearDownModule():
 
 
 class CustomWorkflow(ResourceWorkflow):
+    TYPE = 'testing__custom_resource_workflow_serialization__testing'
+    DISPLAY_TYPE_SINGULAR = 'Custom Serialization Workflow'
+    DISPLAY_TYPE_PLURAL = 'Custom Serialization Workflows'
+
+    __mapper_args__ = {'polymorphic_identity': TYPE}
+
     some_field = 'bar'
     some_date = dt.datetime(2024, 4, 8)
     some_id = uuid.uuid4()
+
+    @classmethod
+    def new(cls, app, name, resource_id, creator_id, geoserver_name, map_manager, spatial_manager, **kwargs):
+        workflow = cls(name=name, resource_id=resource_id, creator_id=creator_id, lock_when_finished=False)
+        test_step = SpatialInputRWS(
+            name='Test Spatial Input Step',
+            order=10,
+            help="This is just for testing step serialization.",
+            options={
+                'shapes': ['points'],
+                'singular_name': 'Point',
+                'plural_name': 'Points',
+                'allow_shapefile': True,
+                'allow_drawing': True,
+            },
+            geoserver_name=geoserver_name,
+            map_manager=map_manager,
+            spatial_manager=spatial_manager,
+        )
+        workflow.steps.append(test_step)
+        test_result_step = ResultsResourceWorkflowStep(
+            name='Test Review Results',
+            order=30,
+            help='This is just for testing results serialization.',
+        )
+        workflow.steps.append(test_result_step)
+
+        test_map_result = SpatialWorkflowResult(
+            name='Test Map Result',
+            codename='generic_map',
+            description='This is just for testing map results serialization.',
+            order=10,
+            options={
+                'layer_group_title': 'Points',
+                'layer_group_control': 'checkbox'
+            },
+            geoserver_name=geoserver_name,
+            map_manager=map_manager,
+            spatial_manager=spatial_manager
+        )
+
+        test_result_step.results.append(test_map_result)
+
+        return workflow
 
     def get_url_name(self):
         return 'custom_workflow'
@@ -35,9 +90,9 @@ class CustomWorkflow(ResourceWorkflow):
 
 
 class CustomResource(Resource):
-    TYPE = 'custom_resource'
-    DISPLAY_TYPE_SINGULAR = 'Custom'
-    DISPLAY_TYPE_PLURAL = 'Customs'
+    TYPE = 'testing__custom_resource_serialization__testing'
+    DISPLAY_TYPE_SINGULAR = 'Custom Serialization Resource'
+    DISPLAY_TYPE_PLURAL = 'Custom Serialization Resources'
     __mapper_args__ = {
         'polymorphic_identity': TYPE,
     }
@@ -60,13 +115,22 @@ class SerializeMixinResourceTests(SqlAlchemyTestCase):
 
     def setUp(self):
         super().setUp()
-        self.instance = Resource(
-            name='Test Resource',
+        self.organization = Organization(
+            name='Test Serialization Oranzation',
+            active=True,
+            license=Organization.LICENSES.STANDARD,
+        )
+
+        self.resource = CustomResource(
+            name='Test Serialization Resource',
             description='A test resource',
             created_by='test_user',
         )
-        self.instance.set_status(Resource.STATUS_AVAILABLE)
-        self.instance.set_attribute('some_attr', 'baz')
+        self.resource.set_status(Resource.STATUS_AVAILABLE)
+        self.resource.set_attribute('some_attr', 'baz')
+        self.resource.organizations.append(self.organization)
+        self.session.add(self.resource)
+        self.session.commit()
 
     def tearDown(self):
         super().tearDown()
@@ -76,103 +140,86 @@ class SerializeMixinResourceTests(SqlAlchemyTestCase):
             d = json.loads(d)
 
         # Verify base fields
-        self.assertEqual(d['id'], self.instance.id)
         if format == 'json':
-            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
+            self.assertEqual(d['id'], str(self.resource.id))
         else:
-            self.assertEqual(d['date_created'], self.instance.date_created)
-        self.assertEqual(d['name'], self.instance.name)
-        self.assertEqual(d['type'], self.instance.type)
+            self.assertEqual(d['id'], self.resource.id)
+        self.assertEqual(d['name'], self.resource.name)
+        self.assertEqual(d['type'], self.resource.type)
+        self.assertEqual(d['locked'], self.resource.is_user_locked)
+        self.assertEqual(d['status'], self.resource.get_status())
+        self.assertDictEqual(d['attributes'], self.resource.attributes)
 
         # Verify Resource fields
-        self.assertEqual(d['description'], self.instance.description)
-        self.assertEqual(d['locked'], self.instance.is_user_locked)
-        self.assertEqual(d['status'], self.instance.get_status())
-        self.assertDictEqual(d['attributes'], self.instance.attributes)
-        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
-        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
-        self.assertEqual(d['slug'], self.instance.SLUG)
+        if format == 'json':
+            self.assertEqual(d['date_created'], self.resource.date_created.isoformat())
+        else:
+            self.assertEqual(d['date_created'], self.resource.date_created)
+        self.assertEqual(d['description'], self.resource.description)
+        self.assertEqual(d['display_type_plural'], self.resource.DISPLAY_TYPE_PLURAL)
+        self.assertEqual(d['display_type_singular'], self.resource.DISPLAY_TYPE_SINGULAR)
+        self.assertEqual(d['slug'], self.resource.SLUG)
+        self.assertFalse(d['public'])
+        self.assertEqual(len(d['organizations']), 1)
+        org_dict = {
+            'id': self.organization.id,
+            'name': 'Test Serialization Oranzation'
+        }
+        if format == 'json':
+            org_dict['id'] = str(self.organization.id)
+        self.assertDictEqual(d['organizations'][0], org_dict)
 
         # Verify custom fields
-        self.assertEqual(d['some_field'], self.instance.some_field)
+        self.assertEqual(d['some_field'], self.resource.some_field)
         if format == 'json':
-            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
+            self.assertEqual(d['some_date'], self.resource.some_date.isoformat())
+            self.assertEqual(d['some_id'], str(self.resource.some_id))
         else:
-            self.assertEqual(d['some_date'], self.instance.some_date)
-        if format == 'json':
-            self.assertEqual(d['some_id'], str(self.instance.some_id))
-        else:
-            self.assertEqual(d['some_id'], self.instance.some_id)
-
-    def verify_resource_workflow_fields(self, d, format='dict'):
-        if format == 'json':
-            d = json.loads(d)
-
-        # Verify base fields
-        self.assertEqual(d['id'], self.instance.id)
-        if format == 'json':
-            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
-        else:
-            self.assertEqual(d['date_created'], self.instance.date_created)
-        self.assertEqual(d['name'], self.instance.name)
-        self.assertEqual(d['type'], self.instance.type)
-
-        # Verify Resource Workflow fields
-        self.assertEqual(d['locked'], self.instance.is_user_locked)
-        self.assertEqual(d['status'], self.instance.get_status())
-        self.assertDictEqual(d['attributes'], self.instance.attributes)
-        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
-        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
-
-        # Verify custom fields
-        self.assertEqual(d['some_field'], self.instance.some_field)
-        if format == 'json':
-            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
-        else:
-            self.assertEqual(d['some_date'], self.instance.some_date)
-        if format == 'json':
-            self.assertEqual(d['some_id'], str(self.instance.some_id))
-        else:
-            self.assertEqual(d['some_id'], self.instance.some_id)
+            self.assertEqual(d['some_date'], self.resource.some_date)
+            self.assertEqual(d['some_id'], self.resource.some_id)
 
     def test_resource_serialize_dict(self):
-        s_dict = self.instance.serialize()
+        s_dict = self.resource.serialize()
         self.assertIsInstance(s_dict, dict)
         self.verify_resource_fields(s_dict, format='dict')
 
     def test_resource_serialize_json(self):
-        s_json = self.instance.serialize(format='json')
+        s_json = self.resource.serialize(format='json')
         self.assertIsInstance(s_json, str)
         self.verify_resource_fields(s_json, format='json')
 
     def test_resource_serialize_invalid_format(self):
         with self.assertRaises(ValueError):
-            self.instance.serialize(format='invalid_format')
+            self.resource.serialize(format='invalid_format')
 
 
 class SerializeMixinResourceWorkflowTests(SqlAlchemyTestCase):
 
     def setUp(self):
         super().setUp()
-        self.instance = ResourceWorkflow(
-            name='Test Resource',
+        self.app_user = self.get_user(return_app_user=True)
+        self.resource = CustomResource(
+            name='Test Serialization Resource',
             description='A test resource',
-            created_by='test_user',
+            created_by='test_user'
         )
-        self.step = ResourceWorkflowStep(
-            name='Test Step',
-            help='A test step',
-            order=1,
+        self.session.add(self.resource)
+        self.session.commit()
+
+        self.workflow = CustomWorkflow.new(
+            app='some_app',
+            name='Test Serialization Workflow',
+            resource_id=self.resource.id,
+            creator_id=self.app_user.id,
+            geoserver_name='foo_geoserver',
+            map_manager=MapManagerBase,
+            spatial_manager=BaseSpatialManager,
         )
-        self.result = ResourceWorkflowResult(
-            name='Test Result',
-            codename='test_result',
-            order=1,
-        )
-        self.instance.steps.append(self.step)
-        self.instance.results.append(self.result)
-        self.instance.set_status(ResourceWorkflow.STATUS_PENDING)
-        self.instance.set_attribute('some_attr', 'baz')
+        self.workflow.set_attribute('some_attr', 'baz')
+        self.session.add(self.workflow)
+        self.session.commit()
+
+        self.workflow_url = '/some/url/to/a/custom-workflow/'
 
     def tearDown(self):
         super().tearDown()
@@ -182,51 +229,90 @@ class SerializeMixinResourceWorkflowTests(SqlAlchemyTestCase):
             d = json.loads(d)
 
         # Verify base fields
-        self.assertEqual(d['id'], self.instance.id)
         if format == 'json':
-            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
+            self.assertEqual(d['id'], str(self.workflow.id))
         else:
-            self.assertEqual(d['date_created'], self.instance.date_created)
-        self.assertEqual(d['name'], self.instance.name)
-        self.assertEqual(d['type'], self.instance.type)
+            self.assertEqual(d['id'], self.workflow.id)
+        self.assertEqual(d['name'], self.workflow.name)
+        self.assertEqual(d['type'], self.workflow.type)
+        self.assertEqual(d['locked'], self.workflow.is_user_locked)
+        self.assertEqual(d['status'], self.workflow.get_status())
+        self.assertDictEqual(d['attributes'], self.workflow.attributes)
 
         # Verify Resource Workflow fields
-        self.assertEqual(d['created_by'], self.instance.created_by)
-        self.assertEqual(d['locked'], self.instance.is_user_locked)
-        self.assertEqual(d['status'], self.instance.get_status())
-        self.assertDictEqual(d['attributes'], self.instance.attributes)
-        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
-        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
+        self.assertEqual(d['created_by'], self.workflow.creator.username)
+        if format == 'json':
+            self.assertEqual(d['date_created'], self.workflow.date_created.isoformat())
+        else:
+            self.assertEqual(d['date_created'], self.workflow.date_created)
+        self.assertEqual(d['display_type_plural'], self.workflow.DISPLAY_TYPE_PLURAL)
+        self.assertEqual(d['display_type_singular'], self.workflow.DISPLAY_TYPE_SINGULAR)
+        self.assertEqual(d['url'], self.workflow_url)
 
         # Verify steps
-        self.assertLen(d['steps'], 1)
-        self.dictEqual(d['steps'][0], {})
+        self.assertEqual(len(d['steps']), 2)
+        self.assertDictEqual(d['steps'][0], {
+            'help': 'This is just for testing step serialization.',
+            'id': str(self.workflow.steps[0].id),
+            'name': 'Test Spatial Input Step',
+            'parameters': {'geometry': None, 'imagery': None},
+            'resource_workflow_id': str(self.workflow.id),
+            'type': 'spatial_input_workflow_step'
+        })
+        self.assertDictEqual(d['steps'][1], {
+            'help': 'This is just for testing results serialization.',
+            'id': str(self.workflow.steps[1].id),
+            'name': 'Test Review Results',
+            'parameters': {},
+            'resource_workflow_id': str(self.workflow.id),
+            'type': 'results_resource_workflow_step'
+        })
 
         # Verify results
-        self.assertLen(d['results'], 1)
-        self.dictEqual(d['results'][0], {})
+        self.assertEqual(len(d['results']), 1)
+        result_dict = {
+            'attributes': {},
+            'codename': 'generic_map',
+            'data': {},
+            'id': self.workflow.steps[1].results[0].id,
+            'name': 'Test Map Result',
+            'order': 10,
+            'status': None,
+            'type': 'spatial_workflow_result'
+        }
+        if format == 'json':
+            result_dict['id'] = str(self.workflow.steps[1].results[0].id)
+        self.assertDictEqual(d['results'][0], result_dict)
 
         # Verify custom fields
-        self.assertEqual(d['some_field'], self.instance.some_field)
+        self.assertEqual(d['some_field'], self.workflow.some_field)
         if format == 'json':
-            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
+            self.assertEqual(d['some_date'], self.workflow.some_date.isoformat())
+            self.assertEqual(d['some_id'], str(self.workflow.some_id))
         else:
-            self.assertEqual(d['some_date'], self.instance.some_date)
-        if format == 'json':
-            self.assertEqual(d['some_id'], str(self.instance.some_id))
-        else:
-            self.assertEqual(d['some_id'], self.instance.some_id)
+            self.assertEqual(d['some_date'], self.workflow.some_date)
+            self.assertEqual(d['some_id'], self.workflow.some_id)
 
-    def test_resource_serialize_dict(self):
-        s_dict = self.instance.serialize()
+    @mock.patch('tethysext.atcore.models.app_users.resource_workflow.reverse')
+    def test_resource_workflow_serialize_dict(self, mock_reverse):
+        mock_reverse.return_value = self.workflow_url
+        s_dict = self.workflow.serialize()
         self.assertIsInstance(s_dict, dict)
-        self.verify_resource_fields(s_dict, format='dict')
+        self.verify_resource_workflow_fields(s_dict, format='dict')
+        mock_reverse.assert_called_with(
+            'custom_workflow', kwargs={'resource_id': self.resource.id, 'workflow_id': self.workflow.id}
+        )
 
-    def test_resource_serialize_json(self):
-        s_json = self.instance.serialize(format='json')
+    @mock.patch('tethysext.atcore.models.app_users.resource_workflow.reverse')
+    def test_resource_workflow_serialize_json(self, mock_reverse):
+        mock_reverse.return_value = self.workflow_url
+        s_json = self.workflow.serialize(format='json')
         self.assertIsInstance(s_json, str)
-        self.verify_resource_fields(s_json, format='json')
+        self.verify_resource_workflow_fields(s_json, format='json')
+        mock_reverse.assert_called_with(
+            'custom_workflow', kwargs={'resource_id': self.resource.id, 'workflow_id': self.workflow.id}
+        )
 
-    def test_resource_serialize_invalid_format(self):
+    def test_resource_workflow_serialize_invalid_format(self):
         with self.assertRaises(ValueError):
-            self.instance.serialize(format='invalid_format')
+            self.workflow.serialize(format='invalid_format')

--- a/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 import datetime as dt
-from tethysext.atcore.models.app_users import Resource, ResourceWorkflow
+from tethysext.atcore.models.app_users import Resource, ResourceWorkflow, ResourceWorkflowResult, ResourceWorkflowStep
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
     tear_down_module_for_sqlalchemy_tests
@@ -159,6 +159,18 @@ class SerializeMixinResourceWorkflowTests(SqlAlchemyTestCase):
             description='A test resource',
             created_by='test_user',
         )
+        self.step = ResourceWorkflowStep(
+            name='Test Step',
+            help='A test step',
+            order=1,
+        )
+        self.result = ResourceWorkflowResult(
+            name='Test Result',
+            codename='test_result',
+            order=1,
+        )
+        self.instance.steps.append(self.step)
+        self.instance.results.append(self.result)
         self.instance.set_status(ResourceWorkflow.STATUS_PENDING)
         self.instance.set_attribute('some_attr', 'baz')
 
@@ -179,11 +191,20 @@ class SerializeMixinResourceWorkflowTests(SqlAlchemyTestCase):
         self.assertEqual(d['type'], self.instance.type)
 
         # Verify Resource Workflow fields
+        self.assertEqual(d['created_by'], self.instance.created_by)
         self.assertEqual(d['locked'], self.instance.is_user_locked)
         self.assertEqual(d['status'], self.instance.get_status())
         self.assertDictEqual(d['attributes'], self.instance.attributes)
         self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
         self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
+
+        # Verify steps
+        self.assertLen(d['steps'], 1)
+        self.dictEqual(d['steps'][0], {})
+
+        # Verify results
+        self.assertLen(d['results'], 1)
+        self.dictEqual(d['results'][0], {})
 
         # Verify custom fields
         self.assertEqual(d['some_field'], self.instance.some_field)

--- a/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/serialize_mixin_tests.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 import datetime as dt
-from tethysext.atcore.models.app_users import Resource
+from tethysext.atcore.models.app_users import Resource, ResourceWorkflow
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
     tear_down_module_for_sqlalchemy_tests
@@ -13,6 +13,25 @@ def setUpModule():
 
 def tearDownModule():
     tear_down_module_for_sqlalchemy_tests()
+
+
+class CustomWorkflow(ResourceWorkflow):
+    some_field = 'bar'
+    some_date = dt.datetime(2024, 4, 8)
+    some_id = uuid.uuid4()
+
+    def get_url_name(self):
+        return 'custom_workflow'
+
+    def serialize_custom_fields(self, d: dict):
+        d.update(
+            {
+                'some_field': self.some_field,
+                'some_date': self.some_date,
+                'some_id': self.some_id,
+            }
+        )
+        return d
 
 
 class CustomResource(Resource):
@@ -37,7 +56,7 @@ class CustomResource(Resource):
         return d
 
 
-class SerializeMixinTests(SqlAlchemyTestCase):
+class SerializeMixinResourceTests(SqlAlchemyTestCase):
 
     def setUp(self):
         super().setUp()
@@ -73,6 +92,98 @@ class SerializeMixinTests(SqlAlchemyTestCase):
         self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
         self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
         self.assertEqual(d['slug'], self.instance.SLUG)
+
+        # Verify custom fields
+        self.assertEqual(d['some_field'], self.instance.some_field)
+        if format == 'json':
+            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
+        else:
+            self.assertEqual(d['some_date'], self.instance.some_date)
+        if format == 'json':
+            self.assertEqual(d['some_id'], str(self.instance.some_id))
+        else:
+            self.assertEqual(d['some_id'], self.instance.some_id)
+
+    def verify_resource_workflow_fields(self, d, format='dict'):
+        if format == 'json':
+            d = json.loads(d)
+
+        # Verify base fields
+        self.assertEqual(d['id'], self.instance.id)
+        if format == 'json':
+            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
+        else:
+            self.assertEqual(d['date_created'], self.instance.date_created)
+        self.assertEqual(d['name'], self.instance.name)
+        self.assertEqual(d['type'], self.instance.type)
+
+        # Verify Resource Workflow fields
+        self.assertEqual(d['locked'], self.instance.is_user_locked)
+        self.assertEqual(d['status'], self.instance.get_status())
+        self.assertDictEqual(d['attributes'], self.instance.attributes)
+        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
+        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
+
+        # Verify custom fields
+        self.assertEqual(d['some_field'], self.instance.some_field)
+        if format == 'json':
+            self.assertEqual(d['some_date'], self.instance.some_date.isoformat())
+        else:
+            self.assertEqual(d['some_date'], self.instance.some_date)
+        if format == 'json':
+            self.assertEqual(d['some_id'], str(self.instance.some_id))
+        else:
+            self.assertEqual(d['some_id'], self.instance.some_id)
+
+    def test_resource_serialize_dict(self):
+        s_dict = self.instance.serialize()
+        self.assertIsInstance(s_dict, dict)
+        self.verify_resource_fields(s_dict, format='dict')
+
+    def test_resource_serialize_json(self):
+        s_json = self.instance.serialize(format='json')
+        self.assertIsInstance(s_json, str)
+        self.verify_resource_fields(s_json, format='json')
+
+    def test_resource_serialize_invalid_format(self):
+        with self.assertRaises(ValueError):
+            self.instance.serialize(format='invalid_format')
+
+
+class SerializeMixinResourceWorkflowTests(SqlAlchemyTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.instance = ResourceWorkflow(
+            name='Test Resource',
+            description='A test resource',
+            created_by='test_user',
+        )
+        self.instance.set_status(ResourceWorkflow.STATUS_PENDING)
+        self.instance.set_attribute('some_attr', 'baz')
+
+    def tearDown(self):
+        super().tearDown()
+
+    def verify_resource_workflow_fields(self, d, format='dict'):
+        if format == 'json':
+            d = json.loads(d)
+
+        # Verify base fields
+        self.assertEqual(d['id'], self.instance.id)
+        if format == 'json':
+            self.assertEqual(d['date_created'], self.instance.date_created.isoformat())
+        else:
+            self.assertEqual(d['date_created'], self.instance.date_created)
+        self.assertEqual(d['name'], self.instance.name)
+        self.assertEqual(d['type'], self.instance.type)
+
+        # Verify Resource Workflow fields
+        self.assertEqual(d['locked'], self.instance.is_user_locked)
+        self.assertEqual(d['status'], self.instance.get_status())
+        self.assertDictEqual(d['attributes'], self.instance.attributes)
+        self.assertEqual(d['display_type_plural'], self.instance.DISPLAY_TYPE_PLURAL)
+        self.assertEqual(d['display_type_singular'], self.instance.DISPLAY_TYPE_SINGULAR)
 
         # Verify custom fields
         self.assertEqual(d['some_field'], self.instance.some_field)

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/resource_workflow_tests/base_methods_tests.py
@@ -283,5 +283,4 @@ class ResourceWorkflowBaseMethodsTests(SqlAlchemyTestCase):
         )
 
     def test_get_url_name(self):
-        ret = self.step_1.workflow.get_url_name()
-        self.assertIsNone(ret)
+        self.assertRaises(NotImplementedError, self.workflow.get_url_name)

--- a/tethysext/atcore/tests/integrated_tests/urls/resources_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/urls/resources_tests.py
@@ -11,7 +11,11 @@ class CustomAppUser(AppUser):
 
 
 class CustomOrganization(Organization):
-    pass
+    TYPE = 'testing__custom_organziation_3__testing'
+    __mapper_args__ = {
+        'polymorphic_on': 'type',
+        'polymorphic_identity': TYPE
+    }
 
 
 class CustomResource(Resource):

--- a/tethysext/atcore/utilities.py
+++ b/tethysext/atcore/utilities.py
@@ -6,8 +6,10 @@
 * Copyright: (c) Aquaveo 2018
 ********************************************************************************
 """
+import datetime
 import re
 from collections import namedtuple
+from uuid import UUID
 
 
 Url = namedtuple('Url', ['protocol', 'username', 'password', 'host', 'port', 'path', 'endpoint'])
@@ -154,6 +156,16 @@ def import_from_string(path):
     # Import the function or class
     obj = getattr(module, obj_name)
     return obj
+
+
+def json_serializer(obj):
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    elif isinstance(obj, UUID):
+        return str(obj)
+    raise TypeError(
+        f'Object of type "{obj.__class__.__name__}" is not JSON serializable'
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Primary changes in this Pull Request:

- Implements a generalized Serialization mixin for Resource models.
- Allows derivative Resources to add custom fields to the serialized values.
- Adds get_url() method to ResourceWorkflow to assist with serialization.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [x] Bonus: Use TypeHints

