### PR TITLE
Fix Select2 dropdown alignment and add env var for jobs table refresh interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use our Tethyscore base docker image as a parent image
-FROM tethysplatform/tethys-core:dev
+FROM tethysplatform/tethys-core:dev-py3.12-dj3.2
 
 #####################
 # Default Variables #

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM tethysplatform/tethys-core:dev
 ENV TETHYSAPP_DIR /var/www/tethys/apps
 ENV TETHYSEXT_DIR /var/www/tethys/exts
 ENV TETHYS_PUBLIC_HOST 'localhost'
+ENV JOBS_TABLE_REFRESH_INTERVAL 30000
 
 #########
 # SETUP #

--- a/tethysext/atcore/controllers/app_users/resource_status.py
+++ b/tethysext/atcore/controllers/app_users/resource_status.py
@@ -6,6 +6,8 @@
 * Copyright: (c) Aquaveo 2018
 ********************************************************************************
 """
+# Python
+import os
 # Django
 from django.shortcuts import render
 from django.urls import reverse
@@ -29,7 +31,7 @@ class ResourceStatus(ResourceViewMixin):
     base_template = 'atcore/app_users/base.html'
     http_method_names = ['get']
     show_detailed_status = True
-    jobs_table_refresh_interval = 30000  # ms
+    jobs_table_refresh_interval = int(os.getenv('JOBS_TABLE_REFRESH_INTERVAL', 30000))  # ms
 
     def get(self, request, *args, **kwargs):
         """

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -27,7 +27,8 @@ class SpatialCondorJobMWV(MapWorkflowView):
     template_name = 'atcore/resource_workflows/spatial_condor_job_mwv.html'
     valid_step_classes = [SpatialCondorJobRWS]
     previous_steps_selectable = True
-    jobs_table_refresh_interval = 30000  # ms
+    jobs_table_refresh_interval = int(os.getenv('JOBS_TABLE_REFRESH_INTERVAL', 30000))  # ms
+
 
     def process_step_options(self, request, session, context, resource, current_step, previous_step, next_step):
         """

--- a/tethysext/atcore/public/gizmos/spatial_reference_select/spatial_reference_select.css
+++ b/tethysext/atcore/public/gizmos/spatial_reference_select/spatial_reference_select.css
@@ -7,8 +7,3 @@
 .select2-container--open .select2-dropdown--below {
     z-index: 1100;
 }
-
-/* Fix 1px misalignment of select2 dropdown */
-.select2-container.select2-container--default.select2-container--open {
-    left: 0 !important;
-}


### PR DESCRIPTION
Primary changes in this Pull Request:

- [Fix issue with select2 dropdown not being aligned.](https://github.com/Aquaveo/tethysext-atcore/commit/ff7170d97ff0c07a463d0125acbd484002ee4a1f)
- [Add env variable for setting jobs table refresh interval](https://github.com/Aquaveo/tethysext-atcore/commit/5970c64cc8bdc11a26f37fcb06b7bc2438df9027)
- [Update FROM tethyscore dev image](https://github.com/Aquaveo/tethysext-atcore/commit/143ed4bf5d477ea4bbbe24ab0c0c61af1edca69e)

Please review the checklist before submitting the Pull Request:

- [ ] Pull request has a meaning full name (not just the commit message from of your last commit)
- [ ] Code has been linted using flake8
- [ ] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

