### PR TITLE
Update plotly server url.

### DIFF
--- a/tethysext/atcore/public/map_view/atcore_cesium_map_view.js
+++ b/tethysext/atcore/public/map_view/atcore_cesium_map_view.js
@@ -547,7 +547,10 @@ var ATCORE_MAP_VIEW = (function() {
         }
 
         m_plot = 'map-plot';
-        m_plot_config = {scrollZoom: true};
+        m_plot_config = {
+            scrollZoom: true,
+            plotlyServerURL: "https://chart-studio.plotly.com",
+        };
 
         let data = [];
 

--- a/tethysext/atcore/public/map_view/atcore_map_view.js
+++ b/tethysext/atcore/public/map_view/atcore_map_view.js
@@ -276,7 +276,10 @@ var ATCORE_MAP_VIEW = (function() {
         }
 
         m_plot = 'map-plot';
-        m_plot_config = {scrollZoom: true};
+        m_plot_config = {
+            scrollZoom: true,
+            plotlyServerURL: "https://chart-studio.plotly.com",
+        };
 
         let data = [];
 
@@ -285,10 +288,14 @@ var ATCORE_MAP_VIEW = (function() {
             height: 415,
             margin: {l: 80, r: 80, t: 20, b: 80},
             xaxis:  {
-                title: 'X Axis Title',
+                title: {
+                    text: 'X Axis Title',
+                },
             },
             yaxis: {
-                title: 'Y Axis Title',
+                title: {
+                    text: 'Y Axis Title',
+                },
             }
         };
 

--- a/tethysext/atcore/public/resource_workflows/spatial_dataset_mwv.js
+++ b/tethysext/atcore/public/resource_workflows/spatial_dataset_mwv.js
@@ -262,6 +262,7 @@ var SPATIAL_DATASET_MWV = (function() {
             modeBarButtonsToRemove: ['zoom2d', 'pan2d', 'select2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d',
                                      'resetScale2d', 'hoverClosestCartesian', 'hoverCompareCartesian',
                                      'toggleSpikelines', 'sendDataToCloud'],
+            plotlyServerURL: "https://chart-studio.plotly.com",
         };
         // Reset column names and selectors
         m_x_column = [];


### PR DESCRIPTION
Fixes issue of importing data into Chart Studio Cloud, which previously brought up this link when clicked on a plot: https://plotly.com/chart-studio-help/getting-data/

Primary changes in this Pull Request:

Updated plotlyServerURL for latest Chart Studio URL.

- 

Please review the checklist before submitting the Pull Request:

- [X] Pull request has a meaning full name (not just the commit message from of your last commit)
- [X] Code has been linted using flake8
- [X] All methods have accurate Google-Style Docstrings
- [ ] 100% test coverage for new content
- [ ] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

