### PR TITLE
Fix issues with tables used by spatial dataset classes.

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_dataset_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_dataset_mwv.py
@@ -81,6 +81,8 @@ class SpatialDatasetMWV(SpatialDataMWV):
             'optional_columns': step.options.get('optional_columns', []),
             'max_rows': max_rows,
             'nodata_val': SPATIAL_DATASET_NODATA,
+            'fixed_rows': step.options.get('fixed_rows', SpatialDatasetRWS.DEFAULT_FIXED_ROWS),
+            'numeric_step': step.options.get('numeric_step', SpatialDatasetRWS.DEFAULT_NUMERIC_STEP),
         }
 
         return render(request, 'atcore/resource_workflows/components/spatial_dataset_form.html', context)

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
@@ -23,6 +23,8 @@ class SpatialDatasetRWS(SpatialResourceWorkflowStep):
         plot_columns(Union[2-tuple, list of 2-tuple]): Two columns to plot. First column given will be plotted on the x axis, the second on the y axis. No plot if not given. Multiple series plotted if a list of 2-tuple given, ex: [(x1, y1), (x2, y2)].
         max_rows(integer): Maximum number of rows allowed in the dataset. No maximum if not given.
         empty_rows(integer): The number of empty rows to generate if an no/empty template dataset is given.
+        fixed_rows(bool): Indicates whether the number of rows in the table is fixed.
+        numeric_step(float): The step increment for numeric columns.
     """  # noqa: #501
     CONTROLLER = 'tethysext.atcore.controllers.resource_workflows.map_workflows.SpatialDatasetMWV'
     TYPE = 'spatial_dataset_workflow_step'
@@ -34,8 +36,10 @@ class SpatialDatasetRWS(SpatialResourceWorkflowStep):
     DEFAULT_DATASET_TITLE = 'Dataset'
     DEFAULT_EMPTY_ROWS = 10
     DEFAULT_MAX_ROWS = 1000
+    DEFAULT_FIXED_ROWS = False
     DEFAULT_COLUMNS = ['X', 'Y']
     DEFAULT_DATASET = pd.DataFrame(columns=DEFAULT_COLUMNS)
+    DEFAULT_NUMERIC_STEP = 0.001
 
     @property
     def default_options(self):
@@ -48,7 +52,9 @@ class SpatialDatasetRWS(SpatialResourceWorkflowStep):
             'plot_columns': [],
             'optional_columns': [],
             'max_rows': self.DEFAULT_MAX_ROWS,
-            'empty_rows': self.DEFAULT_EMPTY_ROWS
+            'empty_rows': self.DEFAULT_EMPTY_ROWS,
+            'fixed_rows': self.DEFAULT_FIXED_ROWS,
+            'numeric_step': self.DEFAULT_NUMERIC_STEP
         })
         return default_options
 

--- a/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
@@ -53,6 +53,8 @@ class SpatialDatasetRWSTests(SqlAlchemyTestCase):
             'optional_columns': [],
             'max_rows': self.instance.DEFAULT_MAX_ROWS,
             'empty_rows': self.instance.DEFAULT_EMPTY_ROWS,
+            'fixed_rows': SpatialDatasetRWS.DEFAULT_FIXED_ROWS,
+            'numeric_step': SpatialDatasetRWS.DEFAULT_NUMERIC_STEP,
             'geocode_enabled': False,
             'label_options': None,
             **RWS_DEFAULT_OPTIONS


### PR DESCRIPTION
Adding options to spatial dataset classes for fixed rows that didn't get added with changes to table input classes.  Fixes issues with spatial dataset input tables that defaulted to a fixed row number, even with max row counts being larger, allowing only a few rows to be entered.  Also fixes an issue where the add and delete row buttons were hidden.

Primary changes in this Pull Request:

Added options for fixed rows and numeric step (float precision) to spatial dataset classes that was added to the table input classes.  Both sets of classes use the same html, so it was working for the table input classes only.

- 

Please review the checklist before submitting the Pull Request:

- [X] Pull request has a meaning full name (not just the commit message from of your last commit)
- [X] Code has been linted using flake8
- [X] All methods have accurate Google-Style Docstrings
- [X] 100% test coverage for new content
- [X] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

