### PR TITLE
Addition of Spatial Dataset Callbacks

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_dataset_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_dataset_mwv.py
@@ -142,6 +142,9 @@ class SpatialDatasetMWV(SpatialDataMWV):
             row_count = max(row_count, len(c))
 
         optional_columns = step.options.get('optional_columns', [])
+        if inspect.isfunction(optional_columns):
+            # If the optional columns are a callback function, call it to get the columns
+            optional_columns = optional_columns(workflow)
         for column in columns:
             if column in optional_columns and not data[column]:
                 c = [SPATIAL_DATASET_NODATA] * row_count

--- a/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
+++ b/tethysext/atcore/models/resource_workflow_steps/spatial_dataset_rws.py
@@ -6,6 +6,7 @@
 * Copyright: (c) Aquaveo 2019
 ********************************************************************************
 """
+import inspect
 import json
 import pandas as pd
 from tethysext.atcore.models.resource_workflow_steps import SpatialResourceWorkflowStep
@@ -152,7 +153,10 @@ class SpatialDatasetRWS(SpatialResourceWorkflowStep):
 
                 # Add some metadata to the dataset object
                 dataset = serialized_datasets[feature_id]
-                columns = self.options.get('template_dataset').columns.to_list()
+                template_dataset = self.options.get('template_dataset')
+                if inspect.isfunction(template_dataset):
+                    template_dataset = template_dataset(self.workflow)
+                columns = template_dataset.columns.to_list()
                 length = len(dataset[columns[0]])
 
                 dataset['meta'] = {

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_dataset_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_dataset_mwv_tests.py
@@ -195,7 +195,7 @@ class SpatialDatasetMwvTests(WorkflowViewTestCase):
         mock_get_step.return_value = optional_step1
         mock_get_param.return_value = {self.request.GET['feature_id']: None}
 
-        ret = SpatialDatasetMWV().get_popup_form(self.request, self.workflow.id, self.step1.id,
+        ret = SpatialDatasetMWV().get_popup_form(self.request, self.workflow.id, optional_step1.id,
                                                  back_url=self.back_url, resource=self.resource, session=self.session)
 
         self.assertIsInstance(ret, HttpResponse)
@@ -203,3 +203,10 @@ class SpatialDatasetMwvTests(WorkflowViewTestCase):
         self.assertIn(search_bytes, ret.content)
         search_bytes = b"[[&quot;Time (min)&quot;, &quot;Discharge (cfs)&quot;]]"
         self.assertIn(search_bytes, ret.content)
+
+        ret = SpatialDatasetMWV().save_spatial_data(self.request, self.workflow.id, optional_step1.id,
+                                                    back_url=self.back_url, resource=self.resource,
+                                                    session=self.session)
+
+        self.assertIsInstance(ret, JsonResponse)
+        self.assertEqual([b'{"success": true}'], ret.__dict__['_container'])

--- a/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/resource_workflow_steps/spatial_dataset_rws_tests.py
@@ -305,6 +305,8 @@ class SpatialDatasetRWSTests(SqlAlchemyTestCase):
                 'dataset_title': 'Hydrograph',
                 'template_dataset': _dataset_callback,
                 'plot_columns': _columns_callback,
+                'read_only_columns': _columns_callback,
+                'optional_columns': _columns_callback,
             },
             geoserver_name='',
             map_manager=m,
@@ -347,3 +349,6 @@ class SpatialDatasetRWSTests(SqlAlchemyTestCase):
         }
         baseline = json.dumps(baseline)
         self.assertEqual(baseline, ret)
+        self.assertEqual(callback_version.options['plot_columns'], _columns_callback)
+        self.assertEqual(callback_version.options['read_only_columns'], _columns_callback)
+        self.assertEqual(callback_version.options['optional_columns'], _columns_callback)


### PR DESCRIPTION
Primary changes in this Pull Request:

Updated Spatial Dataset classes (RWS, MWV) to allow callback functions to be used for the template dataset and column options. Where these are used, we check to see if the option is a function or not, and call the function when that occurs. This allows a variable number of columns when setting up the template datasets in SpatialDatasetRWS steps. Desired plot columns, optional columns, and read only columns can also be customized with a callback function. A common use case would be for running a workflow in a resource group, providing a separate input column for each selected resource, along with plotting the data.

- 

Please review the checklist before submitting the Pull Request:

- [X] Pull request has a meaning full name (not just the commit message from of your last commit)
- [X] Code has been linted using flake8
- [X] All methods have accurate Google-Style Docstrings
- [X] 100% test coverage for new content
- [X] Tests for each common use case (please don't write one test that covers all use cases)
- [X] Bonus: Use TypeHints

Explain deviations from original design if applicable:

