### PR TITLE
Set bounds for param.Integer

### DIFF
--- a/tethysext/atcore/forms/widgets/param_widgets.py
+++ b/tethysext/atcore/forms/widgets/param_widgets.py
@@ -136,6 +136,8 @@ widget_map = {
     param.Integer:
         lambda po, p, name: forms.IntegerField(
             initial=po.param.inspect_value(name) or p.default,
+            max_value=p.bounds[1] if p.bounds else None,
+            min_value=p.bounds[0] if p.bounds else None
         ),
     # TODO: Implement DataFrameField someday...
     # param.DataFrame:


### PR DESCRIPTION
Primary changes in this Pull Request:
- Set bounds for param.Integer in django forms

**For the parameter that doesn't have bounds,** I can input any number I want:

<img width="764" height="99" alt="image" src="https://github.com/user-attachments/assets/dc6888c1-c5e6-4acc-97a8-1ab03f3bca3e" />


**For the parameter that has bounds**:

<img width="762" height="147" alt="image" src="https://github.com/user-attachments/assets/ad870bfb-fa91-4ffd-9add-de6d254f75b8" />

<img width="777" height="142" alt="image" src="https://github.com/user-attachments/assets/1ceb5d26-3e62-4aa6-ae5b-08a7bc0b8e9c" />

The spin buttons won't let me go beyond the range: 

<img width="766" height="94" alt="image" src="https://github.com/user-attachments/assets/b9704c1d-0938-470a-95f1-10a0a4e354f4" />



Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

