### PR TITLE
add TreeSelectorRaster and TreeSelectorCoverage to xmstool_widget_map

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -22,7 +22,8 @@ jobs:
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          self: 'Merge Gatekeeper'
           # Check interval (seconds)
           interval: 30
           # Give up checking (seconds)
-          timeout: 900
+          timeout: 1800

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -22,7 +22,7 @@ jobs:
         uses: upsidr/merge-gatekeeper@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          self: 'Merge Gatekeeper'
+          self: 'merge-gatekeeper'
           # Check interval (seconds)
           interval: 30
           # Give up checking (seconds)

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -279,11 +279,7 @@ def generate_django_form_xmstool(xms_tool_class, form_values, resource=None, for
             p_name = form_field_prefix + p_name
 
         # Get appropriate Django field/widget based on param type
-        if p_info['type'] == 'TreeSelectorRaster' or p_info['type'] == 'TreeSelectorCoverage':
-            # Use the ObjectSelector widget for TreeSelectorRaster and TreeSelectorCoverage types
-            form_class.base_fields[p_name] = xmstool_widget_map['ObjectSelector'](argument_params, p_info, p_name)
-        else:
-            form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
+        form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
 
         # Set label with param label if set, otherwise derive from parameter name
         label = p_info['description']

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -21,22 +21,21 @@ log = logging.getLogger(f'tethys.{__name__}')
 
 
 xmstool_widget_map = {
-    # param.Foldername:
-    #     lambda po, p, name: forms.FilePathField(
-    #         initial=po.param.inspect_value(name) or p.default,
-    #         path=p.search_paths,
-    #     ),
     'Boolean':
         lambda po, interface_info, name: forms.BooleanField(
             initial=interface_info['value'],
             required=False,
         ),
-    # param.Filename:
-    #     lambda po, p, name: forms.FileField(
-    #         initial=po.param.inspect_value(name) or p.default,
-    #     ),
     'String':
         lambda po, interface_info, name: forms.CharField(
+            initial=interface_info['value'],
+        ),
+    'Number':
+        lambda po, interface_info, name: forms.FloatField(
+            initial=interface_info['value'],
+        ),
+    'Integer':
+        lambda po, interface_info, name: forms.IntegerField(
             initial=interface_info['value'],
         ),
     'ObjectSelector':
@@ -51,17 +50,17 @@ xmstool_widget_map = {
             widget=Select2Widget,
             choices=[c for c in d['choices']],
         ),
-    'Number':
-        lambda po, interface_info, name: forms.FloatField(
-            initial=interface_info['value'],
+    'TreeSelectorRaster':
+        lambda po, d, name: forms.ChoiceField(
+            initial=d['value'],
+            widget=Select2Widget,
+            choices=[c for c in d['choices']],
         ),
-    # param.FileSelector:
-    #     lambda po, p, name: forms.ChoiceField(
-    #         initial=po.param.inspect_value(name) or p.default,
-    #     ),
-    'Integer':
-        lambda po, interface_info, name: forms.IntegerField(
-            initial=interface_info['value'],
+    'TreeSelectorCoverage':
+        lambda po, d, name: forms.ChoiceField(
+            initial=d['value'],
+            widget=Select2Widget,
+            choices=[c for c in d['choices']],
         ),
 }
 
@@ -280,7 +279,11 @@ def generate_django_form_xmstool(xms_tool_class, form_values, resource=None, for
             p_name = form_field_prefix + p_name
 
         # Get appropriate Django field/widget based on param type
-        form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
+        if p_info['type'] == 'TreeSelectorRaster' or p_info['type'] == 'TreeSelectorCoverage':
+            # Use the ObjectSelector widget for TreeSelectorRaster and TreeSelectorCoverage types
+            form_class.base_fields[p_name] = xmstool_widget_map['ObjectSelector'](argument_params, p_info, p_name)
+        else:
+            form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
 
         # Set label with param label if set, otherwise derive from parameter name
         label = p_info['description']

--- a/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
+++ b/tethysext/atcore/controllers/resource_workflows/workflow_views/xms_tool_wv.py
@@ -50,18 +50,6 @@ xmstool_widget_map = {
             widget=Select2Widget,
             choices=[c for c in d['choices']],
         ),
-    'TreeSelectorRaster':
-        lambda po, d, name: forms.ChoiceField(
-            initial=d['value'],
-            widget=Select2Widget,
-            choices=[c for c in d['choices']],
-        ),
-    'TreeSelectorCoverage':
-        lambda po, d, name: forms.ChoiceField(
-            initial=d['value'],
-            widget=Select2Widget,
-            choices=[c for c in d['choices']],
-        ),
 }
 
 
@@ -279,7 +267,10 @@ def generate_django_form_xmstool(xms_tool_class, form_values, resource=None, for
             p_name = form_field_prefix + p_name
 
         # Get appropriate Django field/widget based on param type
-        form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
+        param_type = p_info['type']
+        if param_type not in xmstool_widget_map:
+            param_type = 'StringSelector'  # Default to StringSelector if type is not found
+        form_class.base_fields[p_name] = xmstool_widget_map[param_type](argument_params, p_info, p_name)
 
         # Set label with param label if set, otherwise derive from parameter name
         label = p_info['description']


### PR DESCRIPTION
Primary changes in this Pull Request:

xmstool-core 6.5.0 add new parameter types [`TreeSelectorRaster`](https://git.aquaveo.com/Aquaveo/tools/xmstool_core/-/blob/6.5.0/xms/tool_core/raster_argument.py?ref_type=tags#L68) and [`TreeSelectorCoverage`](https://git.aquaveo.com/Aquaveo/tools/xmstool_core/-/blob/6.5.0/xms/tool_core/coverage_argument.py?ref_type=tags#L80), which causes xms_tool_wv.py crash with the error

```
    form_class.base_fields[p_name] = xmstool_widget_map[p_info['type']](argument_params, p_info, p_name)
KeyError: 'TreeSelectorRaster'
```

This PR adds these parameters to `xmstool_widget_map` to fix the issue.

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

