### PR TITLE
Use Tethys 4.5.1 in Docker base image

### DIFF
--- a/.devcontainer/dev_environment.yml
+++ b/.devcontainer/dev_environment.yml
@@ -2,6 +2,7 @@ name: tethys
 
 channels:
 - conda-forge
+- nodefaults
 
 dependencies:
 - alembic

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -20,7 +20,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile.devcontainer
       args:
-        TETHYS_VERSION: "4.4.3"
+        TETHYS_VERSION: "4.5.1"
         PYTHON_VERSION: "3.11"
         DJANGO_VERSION: "4.2"
 

--- a/.github/workflows/push_on_commits_wo_tag.yml
+++ b/.github/workflows/push_on_commits_wo_tag.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        tethys-version: ["4.4.3"]
+        tethys-version: ["4.5.1"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.2"]
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        tethys-version: ["4.4.3"]
+        tethys-version: ["4.5.1"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.2"]
     services:
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        tethys-version: ["4.4.3"]
+        tethys-version: ["4.5.1"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.2"]
     services:

--- a/.github/workflows/push_on_tag.yml
+++ b/.github/workflows/push_on_tag.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        tethys-version: ["4.4.3"]
+        tethys-version: ["4.5.1"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         django-version: ["4.2", "5.2"]
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use our Tethyscore base docker image as a parent image
 ARG PYTHON_VERSION=3.12
 ARG DJANGO_VERSION=3.2
-ARG TETHYS_VERSION=4.3.7
+ARG TETHYS_VERSION=4.5.1
 ARG BASE_IMAGE_TAG="${TETHYS_VERSION}-py${PYTHON_VERSION}-dj${DJANGO_VERSION}"
 ARG BASE_IMAGE="tethysplatform/tethys-core"
 

--- a/install.yml
+++ b/install.yml
@@ -10,6 +10,7 @@ requirements:
   conda:
     channels:
     - conda-forge
+    - nodefaults
     packages:
     - django>=3.2,<6
     - django-select2<8.3.0


### PR DESCRIPTION
Primary changes in this Pull Request:

- Use a Docker base image that has Tethys 4.5.1
- Configure install.yml and dev_environment.yml so the default conda channel isn't used in conda install commands

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [x] Bonus: Use TypeHints

Explain deviations from original design if applicable: N/A

Hi Nathan, if you see this today, say "lets go get cookies" the next time you see me.
