### PR TITLE
Print traceback for resource_controller & refactor exception handling

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/resource_workflow_router.py
+++ b/tethysext/atcore/controllers/resource_workflows/resource_workflow_router.py
@@ -7,6 +7,7 @@
 ********************************************************************************
 """
 import logging
+import traceback
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm.exc import NoResultFound
 from django.shortcuts import redirect, reverse
@@ -98,13 +99,14 @@ class ResourceWorkflowRouter(WorkflowViewMixin):
                 return redirect(reverse(url_name, kwargs=url_kwargs))
 
         except (StatementError, NoResultFound):
+            traceback.print_exc()
             messages.warning(request, 'The {} could not be found.'.format(
                 _ResourceWorkflow.DISPLAY_TYPE_SINGULAR.lower()
             ))
             return redirect(self.back_url)
         except ATCoreException as e:
-            error_message = str(e)
-            messages.warning(request, error_message)
+            traceback.print_exc()
+            messages.warning(request, str(e))
             return redirect(self.back_url)
         finally:
             session and session.close()
@@ -237,13 +239,14 @@ class ResourceWorkflowRouter(WorkflowViewMixin):
             return response
 
         except (StatementError, NoResultFound):
+            traceback.print_exc()
             messages.warning(request, 'Invalid step for workflow: {}.'.format(
                 _ResourceWorkflow.DISPLAY_TYPE_SINGULAR.lower()
             ))
             return redirect(self.back_url)
         except ATCoreException as e:
-            error_message = str(e)
-            messages.warning(request, error_message)
+            traceback.print_exc()
+            messages.warning(request, str(e))
             return redirect(self.back_url)
         finally:
             session and session.close()
@@ -317,8 +320,7 @@ class ResourceWorkflowRouter(WorkflowViewMixin):
             ))
             return redirect(self.back_url)
         except ATCoreException as e:
-            error_message = str(e)
-            messages.warning(request, error_message)
+            messages.warning(request, str(e))
             return redirect(self.back_url)
         finally:
             session and session.close()

--- a/tethysext/atcore/services/app_users/decorators.py
+++ b/tethysext/atcore/services/app_users/decorators.py
@@ -7,6 +7,7 @@
 ********************************************************************************
 """
 import logging
+import traceback
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm.exc import NoResultFound
 from django.http import JsonResponse
@@ -68,6 +69,18 @@ def resource_controller(is_rest_controller=False):
             session = None
             resource = None
 
+            def _handle_exception(e, user_message=None, level=messages.WARNING):
+                """Log traceback and return the appropriate error response."""
+                traceback.print_exc()
+                log.exception(str(e))
+                if isinstance(e, (ValueError, RuntimeError)) and session:
+                    session.rollback()
+                if user_message:
+                    messages.add_message(request, level, user_message)
+                if not is_rest_controller:
+                    return redirect(self.back_url)
+                return JsonResponse({'success': False, 'error': str(e)})
+
             try:
                 make_session = self.get_sessionmaker()
                 session = make_session()
@@ -75,46 +88,25 @@ def resource_controller(is_rest_controller=False):
                 if resource_id:
                     resource = self.get_resource(request, resource_id=resource_id, session=session)
 
-                # Call the Controller
                 return controller_func(self, request, session, resource, back_url, *args, **kwargs)
 
             except (StatementError, NoResultFound) as e:
-                message = 'The {} could not be found.'.format(
-                    _Resource.DISPLAY_TYPE_SINGULAR.lower()
-                )
+                message = f'The {_Resource.DISPLAY_TYPE_SINGULAR.lower()} could not be found.'
                 log.exception(message)
-                messages.warning(request, message)
-                if not is_rest_controller:
-                    return redirect(self.back_url)
-                else:
-                    return JsonResponse({'success': False, 'error': str(e)})
+                return _handle_exception(e, user_message=message)
 
             except ATCoreException as e:
-                error_message = str(e)
-                messages.warning(request, error_message)
-                if not is_rest_controller:
-                    return redirect(self.back_url)
-                else:
-                    return JsonResponse({'success': False, 'error': str(e)})
+                return _handle_exception(e, user_message=str(e))
 
             except ValueError as e:
-                if session:
-                    session.rollback()
-                if not is_rest_controller:
-                    return redirect(self.back_url)
-                else:
-                    return JsonResponse({'success': False, 'error': str(e)})
+                return _handle_exception(e)
 
             except RuntimeError as e:
-                if session:
-                    session.rollback()
-
-                log.exception(str(e))
-                messages.error(request, "We're sorry, an unexpected error has occurred.")
-                if not is_rest_controller:
-                    return redirect(self.back_url)
-                else:
-                    return JsonResponse({'success': False, 'error': str(e)})
+                return _handle_exception(
+                    e,
+                    user_message="We're sorry, an unexpected error has occurred.",
+                    level=messages.ERROR,
+                )
 
             finally:
                 session and session.close()

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/resource_workflow_router_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/resource_workflow_router_tests.py
@@ -169,6 +169,12 @@ class ResourceWorkflowRouterTests(SqlAlchemyTestCase):
         self.mock_get_workflow.return_value = self.workflow
         self.addCleanup(get_workflow_patcher.stop)
 
+        traceback_patcher = mock.patch(
+            'tethysext.atcore.controllers.resource_workflows.resource_workflow_router.traceback'
+        )
+        traceback_patcher.start()
+        self.addCleanup(traceback_patcher.stop)
+
     def tearDown(self):
         super().tearDown()
 

--- a/tethysext/atcore/tests/integrated_tests/services/app_users/decorators.py
+++ b/tethysext/atcore/tests/integrated_tests/services/app_users/decorators.py
@@ -132,6 +132,10 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
         self.mock_log = log_patcher.start()
         self.addCleanup(log_patcher.stop)
 
+        traceback_patcher = mock.patch('tethysext.atcore.services.app_users.decorators.traceback')
+        traceback_patcher.start()
+        self.addCleanup(traceback_patcher.stop)
+
     @override_settings(ENABLE_OPEN_PORTAL=False)
     def assertIsRedirect(self, response, to='/apps/'):
         self.assertIsInstance(response, HttpResponseRedirect)
@@ -216,8 +220,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_statement_error(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('The generic resource could not be found.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('The generic resource could not be found.', msg_args[0][0][2])
         self.assertEqual('The generic resource could not be found.', self.mock_log.exception.call_args_list[0][0][0])
         self.assertEqual(MockResourceController.back_url, response.url)
 
@@ -226,8 +230,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_statement_error_as_rest_controller(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('The generic resource could not be found.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('The generic resource could not be found.', msg_args[0][0][2])
         self.assertEqual('The generic resource could not be found.', self.mock_log.exception.call_args_list[0][0][0])
         response_dict = json.loads(response._container[0])
         self.assertFalse(response_dict['success'])
@@ -238,8 +242,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_no_result_found(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('The generic resource could not be found.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('The generic resource could not be found.', msg_args[0][0][2])
         self.assertEqual('The generic resource could not be found.', self.mock_log.exception.call_args_list[0][0][0])
         self.assertEqual(MockResourceController.back_url, response.url)
 
@@ -248,8 +252,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_no_result_found_as_rest_controller(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('The generic resource could not be found.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('The generic resource could not be found.', msg_args[0][0][2])
         self.assertEqual('The generic resource could not be found.', self.mock_log.exception.call_args_list[0][0][0])
         response_dict = json.loads(response._container[0])
         self.assertFalse(response_dict['success'])
@@ -260,8 +264,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_atcore_exception(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('This is the ATCore exception.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('This is the ATCore exception.', msg_args[0][0][2])
         self.assertEqual(MockResourceController.back_url, response.url)
 
     def test_resource_controller_atcore_exception_as_rest_controller(self):
@@ -269,8 +273,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_atcore_exception_as_rest_controller(self.request)
 
-        msg_args = self.mock_messages.warning.call_args_list
-        self.assertEqual('This is the ATCore exception.', msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual('This is the ATCore exception.', msg_args[0][0][2])
         response_dict = json.loads(response._container[0])
         self.assertFalse(response_dict['success'])
         self.assertEqual('This is the ATCore exception.', response_dict['error'])
@@ -296,8 +300,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_runtime_error(self.request)
 
-        msg_args = self.mock_messages.error.call_args_list
-        self.assertEqual("We're sorry, an unexpected error has occurred.", msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual("We're sorry, an unexpected error has occurred.", msg_args[0][0][2])
         self.assertEqual('This is the Runtime Error', self.mock_log.exception.call_args_list[0][0][0])
         self.assertEqual(MockResourceController.back_url, response.url)
 
@@ -306,8 +310,8 @@ class ActiveUserRequiredDecoratorTests(SqlAlchemyTestCase):
 
         response = MockResourceController().raise_runtime_error_as_rest_controller(self.request)
 
-        msg_args = self.mock_messages.error.call_args_list
-        self.assertEqual("We're sorry, an unexpected error has occurred.", msg_args[0][0][1])
+        msg_args = self.mock_messages.add_message.call_args_list
+        self.assertEqual("We're sorry, an unexpected error has occurred.", msg_args[0][0][2])
         self.assertEqual('This is the Runtime Error', self.mock_log.exception.call_args_list[0][0][0])
         response_dict = json.loads(response._container[0])
         self.assertFalse(response_dict['success'])


### PR DESCRIPTION
Primary changes in this Pull Request:

- Refactored the `resource_controller` decorator to consolidate the repetitive exception handling blocks into a single `_handle_exception` helper
- Added `traceback.print_exc()` for terminal visibility so silently-swallowed exceptions can now be debugged

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

