### PR TITLE
Update version inference for steuptool-scm 9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-scm"]
+requires = ["setuptools>=80", "wheel", "setuptools-scm[simple]"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ exclude = ["ez_setup", "examples", "docker", ".github", "docs", "helm", "tethyse
     "public/**/*",
     "resources/**/*",
 ]
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=80", "wheel", "setuptools-scm[simple]"]
+requires = ["setuptools>=80", "wheel", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Description

When installing `atcore`, the reported version was `0.0.0`. The root cause is that `setuptools-scm` removed its legacy simplified activation in 9.2.0, so version inference no longer kicks in automatically from the old configuration. This PR updates `pyproject.toml` to use the currently recommended activation so the version is correctly derived from SCM metadata at build/install time.

Reference: [setuptools-scm — Recommended build workflows](https://setuptools-scm.readthedocs.io/en/latest/usage/)

## Changes

- Use `"setuptools-scm[simple]>=9.2"` in [build-systems.requires] instead of just `setuptoools-scm`

## Result

`atcore` now reports the correct version on install instead of `0.0.0`.


## Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [x] Bonus: Use TypeHints

Explain deviations from original design if applicable:

