### PR TITLE
Delete previous condor job on resubmit

### DIFF
--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -304,6 +304,13 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # Add parameter file to workflow input files
         condor_job_manager.input_files.append(params_file_path)
 
+        # Delete the previous condor job before submitting a new one to avoid orphaned/stuck jobs
+        previous_condor_job_id = step.get_attribute('condor_job_id')
+        if previous_condor_job_id:
+            previous_job = app.get_job_manager().get_job(job_id=previous_condor_job_id)
+            if previous_job:
+                previous_job.delete()
+
         # Prepare the job
         job_id = condor_job_manager.prepare()
 

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -293,6 +293,18 @@ class SpatialCondorJobMWV(MapWorkflowView):
             workflow_kwargs=workflow_kwargs,
         )
 
+        # Delete the previous condor job first so its pre_delete signal doesn't remove the new workspace
+        previous_condor_job_id = step.get_attribute('condor_job_id')
+        if previous_condor_job_id:
+            previous_job = app.get_job_manager().get_job(job_id=previous_condor_job_id)
+            if previous_job:
+                previous_job.delete()
+            # Restore CWD to working_directory in case condorpy's @set_cwd left it pointing
+            # to the now-deleted workspace (condor_workflow_pre_delete calls close_remote which
+            # uses @set_cwd; if that leaves CWD in the old workspace, os.getcwd() will fail
+            # when condorpy tries to submit the new job)
+            os.chdir(working_directory)
+
         # Serialize parameters from all previous steps into json
         serialized_params = self.serialize_parameters(step)
 
@@ -303,13 +315,6 @@ class SpatialCondorJobMWV(MapWorkflowView):
 
         # Add parameter file to workflow input files
         condor_job_manager.input_files.append(params_file_path)
-
-        # Delete the previous condor job before submitting a new one to avoid orphaned/stuck jobs
-        previous_condor_job_id = step.get_attribute('condor_job_id')
-        if previous_condor_job_id:
-            previous_job = app.get_job_manager().get_job(job_id=previous_condor_job_id)
-            if previous_job:
-                previous_job.delete()
 
         # Prepare the job
         job_id = condor_job_manager.prepare()

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -363,6 +363,138 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
 
+    @mock.patch.object(AppUsersViewMixin, 'get_app')
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'prepare')
+    @mock.patch.object(SpatialCondorJobMWV, 'get_working_directory')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
+    def test_run_job__deletes_previous_job(self, mock_model_db, mock_get_map_manager, mock_get_working_dir,
+                                           mock_prepare, mock_run_job, mock_is_read_only, mock_get_app):
+        previous_job_id = 'old-job-abc-123'
+        mock_previous_job = mock.MagicMock()
+        mock_job_manager = mock.MagicMock()
+        mock_job_manager.get_job.return_value = mock_previous_job
+        mock_app = mock.MagicMock()
+        mock_app.get_job_manager.return_value = mock_job_manager
+        mock_get_app.return_value = mock_app
+
+        mock_model_db.return_value = mock.MagicMock(db_url='fake_db_url')
+        mock_get_map_manager.return_value = mock.MagicMock(
+            spec=MapManagerBase,
+            spatial_manager=mock.MagicMock(gs_engine=mock.MagicMock())
+        )
+        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        mock_prepare.return_value = self.workflow.id
+
+        session = mock.MagicMock()
+        self.step.workflow = mock.MagicMock()
+        self.step.workflow.resource = self.resource
+        self.step.set_attribute('condor_job_id', previous_job_id)
+        self.request.user = UserFactory()
+        self.request.POST['run-submit'] = True
+        self.step.options['scheduler'] = 'my_schedule'
+        self.step.options['jobs'] = [{
+            'name': 'base_scenario',
+            'condorpy_template_name': 'vanilla_transfer_files',
+            'remote_input_files': [None],
+            'attributes': {'executable': 'run.py', 'transfer_output_files': []}
+        }]
+
+        ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
+
+        mock_job_manager.get_job.assert_called_once_with(job_id=previous_job_id)
+        mock_previous_job.delete.assert_called_once()
+        self.assertIsInstance(ret, HttpResponseRedirect)
+        self.assertEqual(self.request.path, ret.url)
+
+    @mock.patch.object(AppUsersViewMixin, 'get_app')
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'prepare')
+    @mock.patch.object(SpatialCondorJobMWV, 'get_working_directory')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
+    def test_run_job__no_previous_job_id(self, mock_model_db, mock_get_map_manager, mock_get_working_dir,
+                                         mock_prepare, mock_run_job, mock_is_read_only, mock_get_app):
+        mock_job_manager = mock.MagicMock()
+        mock_app = mock.MagicMock()
+        mock_app.get_job_manager.return_value = mock_job_manager
+        mock_get_app.return_value = mock_app
+
+        mock_model_db.return_value = mock.MagicMock(db_url='fake_db_url')
+        mock_get_map_manager.return_value = mock.MagicMock(
+            spec=MapManagerBase,
+            spatial_manager=mock.MagicMock(gs_engine=mock.MagicMock())
+        )
+        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        mock_prepare.return_value = self.workflow.id
+
+        session = mock.MagicMock()
+        self.step.workflow = mock.MagicMock()
+        self.step.workflow.resource = self.resource
+        # condor_job_id is not set on the step (first run)
+        self.request.user = UserFactory()
+        self.request.POST['run-submit'] = True
+        self.step.options['scheduler'] = 'my_schedule'
+        self.step.options['jobs'] = [{
+            'name': 'base_scenario',
+            'condorpy_template_name': 'vanilla_transfer_files',
+            'remote_input_files': [None],
+            'attributes': {'executable': 'run.py', 'transfer_output_files': []}
+        }]
+
+        ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
+
+        mock_job_manager.get_job.assert_not_called()
+        self.assertIsInstance(ret, HttpResponseRedirect)
+        self.assertEqual(self.request.path, ret.url)
+
+    @mock.patch.object(AppUsersViewMixin, 'get_app')
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'prepare')
+    @mock.patch.object(SpatialCondorJobMWV, 'get_working_directory')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
+    def test_run_job__previous_job_already_gone(self, mock_model_db, mock_get_map_manager, mock_get_working_dir,
+                                                mock_prepare, mock_run_job, mock_is_read_only, mock_get_app):
+        previous_job_id = 'stale-job-xyz-999'
+        mock_job_manager = mock.MagicMock()
+        mock_job_manager.get_job.return_value = None  # job no longer exists in Tethys
+        mock_app = mock.MagicMock()
+        mock_app.get_job_manager.return_value = mock_job_manager
+        mock_get_app.return_value = mock_app
+
+        mock_model_db.return_value = mock.MagicMock(db_url='fake_db_url')
+        mock_get_map_manager.return_value = mock.MagicMock(
+            spec=MapManagerBase,
+            spatial_manager=mock.MagicMock(gs_engine=mock.MagicMock())
+        )
+        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        mock_prepare.return_value = self.workflow.id
+
+        session = mock.MagicMock()
+        self.step.workflow = mock.MagicMock()
+        self.step.workflow.resource = self.resource
+        self.step.set_attribute('condor_job_id', previous_job_id)
+        self.request.user = UserFactory()
+        self.request.POST['rerun-submit'] = True
+        self.step.options['scheduler'] = 'my_schedule'
+        self.step.options['jobs'] = [{
+            'name': 'base_scenario',
+            'condorpy_template_name': 'vanilla_transfer_files',
+            'remote_input_files': [None],
+            'attributes': {'executable': 'run.py', 'transfer_output_files': []}
+        }]
+
+        ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
+
+        mock_job_manager.get_job.assert_called_once_with(job_id=previous_job_id)
+        self.assertIsInstance(ret, HttpResponseRedirect)
+        self.assertEqual(self.request.path, ret.url)
+
     def test_get_working_directory(self):
         user = UserFactory()
         self.request.user = user

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -385,7 +385,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
             spec=MapManagerBase,
             spatial_manager=mock.MagicMock(gs_engine=mock.MagicMock())
         )
-        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        working_dir = os.path.join(self.working_dir_path, 'working_dir')
+        mock_get_working_dir.return_value = working_dir
         mock_prepare.return_value = self.workflow.id
 
         session = mock.MagicMock()
@@ -402,10 +403,12 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
             'attributes': {'executable': 'run.py', 'transfer_output_files': []}
         }]
 
-        ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
+        with mock.patch('tethysext.atcore.controllers.resource_workflows.map_workflows.spatial_condor_job_mwv.os.chdir') as mock_chdir:  # noqa: E501
+            ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
 
         mock_job_manager.get_job.assert_called_once_with(job_id=previous_job_id)
         mock_previous_job.delete.assert_called_once()
+        mock_chdir.assert_called_once_with(working_dir)
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
 
@@ -489,7 +492,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
             'attributes': {'executable': 'run.py', 'transfer_output_files': []}
         }]
 
-        ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
+        with mock.patch('tethysext.atcore.controllers.resource_workflows.map_workflows.spatial_condor_job_mwv.os.chdir'):  # noqa: E501
+            ret = SpatialCondorJobMWV().run_job(self.request, session, self.resource, self.workflow.id, self.step.id)
 
         mock_job_manager.get_job.assert_called_once_with(job_id=previous_job_id)
         self.assertIsInstance(ret, HttpResponseRedirect)


### PR DESCRIPTION
Primary changes in this Pull Request:
Update for the rerun/resubmit functionality for a workflow step, to first delete the previous condor job (if there) before starting the new one.  Addresses issues when trying to rerun a model because the old job is still running or stuck on hold in Condor.
- 

Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

