### PR TITLE
Filter data tables

### DIFF
--- a/tethysext/atcore/controllers/app_users/manage_organizations.py
+++ b/tethysext/atcore/controllers/app_users/manage_organizations.py
@@ -27,6 +27,9 @@ class ManageOrganizations(MultipleResourcesViewMixin):
     template_name = 'atcore/app_users/manage_organizations.html'
     base_template = 'atcore/app_users/base.html'
     http_method_names = ['get', 'delete']
+    # Show a client-side search box that instantly filters the organization cards by name.
+    # On by default; set False in a subclass to hide it.
+    enable_search = True
 
     def get(self, request, *args, **kwargs):
         """
@@ -137,7 +140,9 @@ class ManageOrganizations(MultipleResourcesViewMixin):
         context = self.get_base_context(request)
         context.update({
             'page_title': _Organization.DISPLAY_TYPE_PLURAL,
+            'type_singular': _Organization.DISPLAY_TYPE_SINGULAR,
             'base_template': self.base_template,
+            'enable_search': self.enable_search,
             'organization_cards': organization_cards,
             'show_new_button': can_create_organizations,
             'load_delete_modal': load_delete_modal,

--- a/tethysext/atcore/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/controllers/app_users/manage_resources.py
@@ -43,6 +43,9 @@ class ManageResources(ResourceViewMixin):
     collapse_groups = False
     highlight_groups = False
     show_archive_button = False
+    # Opt-in: set True in a subclass to render the list as a client-side jQuery DataTable
+    # (search box, sortable headers, page-size selector). Ignored when enable_groups is True.
+    enable_datatable = False
 
     ACTION_LAUNCH = 'launch'
     ACTION_PROCESSING = 'processing'
@@ -105,6 +108,9 @@ class ManageResources(ResourceViewMixin):
         page = int(params.get('page', 1))
         resources_per_page = params.get('show', None)
         sort_by_raw = params.get('sort_by', None)
+        # Transient (not persisted as a user setting) server-side search term. Only used on the
+        # non-DataTable path; the DataTable filters client-side and never sends this param.
+        search = (params.get('search', '') or '').strip()
 
         # Update setting if user made a change
         if resources_per_page:
@@ -212,6 +218,16 @@ class ManageResources(ResourceViewMixin):
 
         resource_cards = build_resource_cards(all_resources)
 
+        # DataTables handles search/sort/paging client-side, so it needs all rows rendered.
+        # Server-side pagination is only used for the grouped (hierarchical) view.
+        use_datatable = self.enable_datatable and not self.enable_groups
+
+        # Apply the server-side search filter when the search feature is enabled but the
+        # client-side DataTable is not in use (i.e. the grouped view). The filter is
+        # hierarchy-aware so parent/child relationships in the grouped view are preserved.
+        if search and self.enable_datatable and not use_datatable:
+            resource_cards = self.filter_resource_cards(resource_cards, search.lower())
+
         # Generate pagination
         paginated_resources, pagination_info = paginate(
             objects=resource_cards,
@@ -221,8 +237,21 @@ class ManageResources(ResourceViewMixin):
             sort_by_raw=sort_by_raw,
             sort_reversed=sort_reversed
         )
+
+        # The DataTable paginates in the browser, so render every card rather than a single
+        # server-side page. The user's settings still drive the initial state via pagination_info.
+        if use_datatable:
+            paginated_resources = resource_cards
+
+        # Make the active search term available to the pagination links and the search input.
+        # Empty on the DataTable path.
+        pagination_info['search'] = search
+
         context = self.get_base_context(request)
         context.update({
+            'enable_datatable': self.enable_datatable,
+            'use_datatable': use_datatable,
+            'search': search,
             'collapse_groups': self.collapse_groups,
             'highlight_groups': self.highlight_groups,
             'page_title': _Resource.DISPLAY_TYPE_PLURAL,
@@ -435,6 +464,52 @@ class ManageResources(ResourceViewMixin):
         _Resource = self.get_resource_model()
         return request_app_user.get_resources(
             session, request, of_type=_Resource, include_children=not self.enable_groups
+        )
+
+    def filter_resource_cards(self, resource_cards, search_lower, ancestor_match=False):
+        """
+        Recursively filter resource cards by a (lower-cased) search term, preserving hierarchy.
+
+        A card is kept if it matches, if one of its ancestors matched (in which case the whole
+        subtree is kept), or if one of its descendants matched (so the ancestor chain leading to a
+        match is retained). Non-matching branches are pruned.
+
+        Args:
+            resource_cards(list<dict>): resource cards to filter (each may contain a 'children' list).
+            search_lower(str): the search term, already lower-cased.
+            ancestor_match(bool): True if an ancestor of these cards already matched the term.
+
+        Returns:
+            list<dict>: the filtered (and pruned) list of resource cards.
+        """
+        filtered = []
+        for resource_card in resource_cards:
+            self_match = ancestor_match or self.resource_card_matches_search(resource_card, search_lower)
+            children = self.filter_resource_cards(
+                resource_card.get('children') or [], search_lower, self_match
+            )
+            if self_match or children:
+                resource_card['children'] = children
+                filtered.append(resource_card)
+        return filtered
+
+    def resource_card_matches_search(self, resource_card, search_lower):
+        """
+        Hook to determine whether a single resource card matches the search term.
+
+        Override to change which fields are searched. The term is a case-insensitive substring.
+
+        Args:
+            resource_card(dict): the resource card to test.
+            search_lower(str): the search term, already lower-cased.
+
+        Returns:
+            bool: True if the card matches the search term.
+        """
+        return (
+            search_lower in (resource_card.get('name') or '').lower()
+            or search_lower in (resource_card.get('description') or '').lower()
+            or search_lower in (resource_card.get('created_by') or '').lower()
         )
 
     def perform_custom_delete_operations(self, session, request, resource):

--- a/tethysext/atcore/controllers/app_users/manage_users.py
+++ b/tethysext/atcore/controllers/app_users/manage_users.py
@@ -31,6 +31,10 @@ class ManageUsers(AppUsersViewMixin):
     template_name = 'atcore/app_users/manage_users.html'
     base_template = 'atcore/app_users/base.html'
     http_method_names = ['get', 'delete']
+    # Render the user list as a client-side jQuery DataTable (search box, sortable headers,
+    # page-size selector). On by default; set False in a subclass to fall back to the plain
+    # server-paginated table.
+    enable_datatable = True
 
     def get(self, request, *args, **kwargs):
         """
@@ -131,11 +135,19 @@ class ManageUsers(AppUsersViewMixin):
             result_name='users'
         )
 
+        # The DataTable paginates/searches in the browser, so render every row rather than a
+        # single server-side page.
+        use_datatable = self.enable_datatable
+        if use_datatable:
+            paginated_user_cards = user_cards
+
         context = self.get_base_context(request)
 
         context.update({
             'page_title': self.page_title,
             'base_template': self.base_template,
+            'enable_datatable': self.enable_datatable,
+            'use_datatable': use_datatable,
             'user_cards': paginated_user_cards,
             'show_new_button': has_permission(request, 'modify_users'),
             'show_action_buttons': has_permission(request, 'modify_users'),

--- a/tethysext/atcore/public/app_users/js/manage_organizations_filter.js
+++ b/tethysext/atcore/public/app_users/js/manage_organizations_filter.js
@@ -1,0 +1,88 @@
+/**
+ * Instant client-side filter for the manage_organizations card list.
+ *
+ * The organizations page is a list of collapsible cards grouped by license rather than a table,
+ * so jQuery DataTables does not apply. This filters the rendered cards by organization name as the
+ * user types: non-matching cards are hidden, license groups with no visible cards are hidden, and a
+ * "no results" message is shown when nothing matches. Each card carries its searchable text in a
+ * data-search attribute (set in the template).
+ */
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var input = document.getElementById('organization-search-input');
+        var clear = document.getElementById('organization-search-clear');
+        var noResults = document.getElementById('organization-no-results');
+        var info = document.getElementById('organization-info');
+
+        if (!input) {
+            return;
+        }
+
+        var total = document.querySelectorAll('.manage-card').length;
+        var labelPlural = (info && info.getAttribute('data-label')) || 'entries';
+        var labelSingular = (info && info.getAttribute('data-label-singular')) || labelPlural;
+
+        function label(count) {
+            return count === 1 ? labelSingular : labelPlural;
+        }
+
+        function updateInfo(matched, isFiltered) {
+            if (!info) {
+                return;
+            }
+            if (isFiltered) {
+                info.textContent = 'Showing ' + matched + ' ' + label(matched) +
+                    ' (filtered from ' + total + ' total)';
+            } else {
+                info.textContent = 'Showing ' + total + ' ' + label(total);
+            }
+        }
+
+        function applyFilter() {
+            var term = input.value.trim().toLowerCase();
+            var isFiltered = term.length > 0;
+
+            if (clear) {
+                clear.classList.toggle('d-none', !isFiltered);
+            }
+
+            var matched = 0;
+
+            document.querySelectorAll('.organization-license-group').forEach(function (group) {
+                var groupHasMatch = false;
+
+                group.querySelectorAll('.manage-card').forEach(function (card) {
+                    var haystack = (card.getAttribute('data-search') || '').toLowerCase();
+                    var match = term === '' || haystack.indexOf(term) > -1;
+                    card.classList.toggle('d-none', !match);
+                    if (match) {
+                        groupHasMatch = true;
+                        matched += 1;
+                    }
+                });
+
+                // Hide a license group heading when none of its cards match.
+                group.classList.toggle('d-none', !groupHasMatch);
+            });
+
+            if (noResults) {
+                noResults.classList.toggle('d-none', matched > 0);
+            }
+
+            updateInfo(matched, isFiltered);
+        }
+
+        input.addEventListener('keyup', applyFilter);
+
+        if (clear) {
+            clear.addEventListener('click', function () {
+                input.value = '';
+                applyFilter();
+                input.focus();
+            });
+        }
+
+        // Populate the count on load.
+        applyFilter();
+    });
+})();

--- a/tethysext/atcore/public/app_users/js/manage_resources_datatable.js
+++ b/tethysext/atcore/public/app_users/js/manage_resources_datatable.js
@@ -1,0 +1,63 @@
+/**
+ * Initialize a client-side DataTable on the manage_resources table.
+ *
+ * All resource rows are rendered into the page by the server, and DataTables
+ * handles searching, sorting, paging, and page-size selection in the browser.
+ * Columns flagged with the "no-sort" class (select checkbox, organizations, and
+ * the action-button column) are excluded from ordering and search.
+ */
+$(function () {
+    var $table = $('#resource_table');
+
+    if ($table.length === 0 || $.fn.DataTable.isDataTable($table)) {
+        return;
+    }
+
+    var table = $table.DataTable({
+        // "dom" omits the default search box ("f"); the custom, app-styled search input in the
+        // page toolbar drives filtering instead. Layout: length menu, processing, table, info, paging.
+        "dom": "lrtip",
+        "order": [],
+        "pageLength": 10,
+        "lengthMenu": [5, 10, 20, 40, 80, 120],
+        "stateSave": true,
+        "columnDefs": [
+            {"orderable": false, "searchable": false, "targets": "no-sort"}
+        ]
+    });
+
+    // Wire the custom toolbar search input to the DataTable's client-side search.
+    var $input = $('#resource-search-input');
+    var $clear = $('#resource-search-clear');
+
+    function syncClearButton(value) {
+        $clear.toggleClass('d-none', !value);
+    }
+
+    // Restore any search term remembered by stateSave.
+    var savedSearch = table.search();
+    if (savedSearch) {
+        $input.val(savedSearch);
+        syncClearButton(savedSearch);
+    }
+
+    $input.on('keyup', function () {
+        table.search(this.value).draw();
+        syncClearButton(this.value);
+    });
+
+    $clear.on('click', function () {
+        $input.val('');
+        table.search('').draw();
+        syncClearButton('');
+    });
+
+    // Bootstrap tooltips must be re-initialized after each redraw because
+    // DataTables re-attaches row elements when paging/searching/sorting.
+    table.on('draw', function () {
+        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.map(function (el) {
+            return bootstrap.Tooltip.getOrCreateInstance(el);
+        });
+    });
+});

--- a/tethysext/atcore/public/app_users/js/manage_users_datatable.js
+++ b/tethysext/atcore/public/app_users/js/manage_users_datatable.js
@@ -1,0 +1,61 @@
+/**
+ * Initialize a client-side DataTable on the manage_users table.
+ *
+ * All user rows are rendered into the page by the server, and DataTables handles searching,
+ * sorting, paging, and page-size selection in the browser. The "Organizations" and action-button
+ * columns (flagged with the "no-sort" class) are excluded from ordering and search. DataTables'
+ * built-in search box is suppressed ("dom" omits "f"); the app-styled toolbar input drives filtering.
+ */
+$(function () {
+    var $table = $('#user_table');
+
+    if ($table.length === 0 || $.fn.DataTable.isDataTable($table)) {
+        return;
+    }
+
+    var table = $table.DataTable({
+        "dom": "lrtip",
+        "order": [],
+        "pageLength": 10,
+        "lengthMenu": [5, 10, 20, 40, 80, 120],
+        "stateSave": true,
+        "columnDefs": [
+            {"orderable": false, "searchable": false, "targets": "no-sort"}
+        ]
+    });
+
+    // Wire the custom toolbar search input to the DataTable's client-side search.
+    var $input = $('#user-search-input');
+    var $clear = $('#user-search-clear');
+
+    function syncClearButton(value) {
+        $clear.toggleClass('d-none', !value);
+    }
+
+    // Restore any search term remembered by stateSave.
+    var savedSearch = table.search();
+    if (savedSearch) {
+        $input.val(savedSearch);
+        syncClearButton(savedSearch);
+    }
+
+    $input.on('keyup', function () {
+        table.search(this.value).draw();
+        syncClearButton(this.value);
+    });
+
+    $clear.on('click', function () {
+        $input.val('');
+        table.search('').draw();
+        syncClearButton('');
+    });
+
+    // Bootstrap tooltips must be re-initialized after each redraw because
+    // DataTables re-attaches row elements when paging/searching/sorting.
+    table.on('draw', function () {
+        var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.map(function (el) {
+            return bootstrap.Tooltip.getOrCreateInstance(el);
+        });
+    });
+});

--- a/tethysext/atcore/templates/atcore/app_users/manage_organizations.html
+++ b/tethysext/atcore/templates/atcore/app_users/manage_organizations.html
@@ -8,7 +8,17 @@
 
 {% block app_content %}
   <div class="manage-container">
-    <div class="top-action-buttons float-end">
+    <div class="top-action-buttons float-end d-flex align-items-center">
+      {# SEARCH BOX #}
+      {% if enable_search %}
+      <div class="me-2 d-flex align-items-center" role="search">
+        <div class="input-group">
+          <span class="input-group-text"><i class="bi bi-search"></i></span>
+          <input type="text" class="form-control" id="organization-search-input" placeholder="Search…" aria-label="Search organizations">
+          <a class="btn btn-outline-secondary d-none" id="organization-search-clear" href="javascript:void(0);" title="Clear search"><i class="bi bi-x-lg"></i></a>
+        </div>
+      </div>
+      {% endif %}
       {# NEW ORG BUTTON #}
       {% if show_new_button %}
       <a class="btn btn-outline-secondary manage-action-btn btn-new"
@@ -22,12 +32,16 @@
     </div>
     <h1>{% block organizations_title %}{{ page_title }}{% endblock %}</h1>
 
+    {% if enable_search %}
+    <div id="organization-info" class="text-muted small text-end mb-2" data-label="{{ page_title|lower }}" data-label-singular="{{ type_singular|lower }}"></div>
+    {% endif %}
+
     {% for organization_license, organization_cards in organization_cards.items %}
       <div class="organization-license-group mb-3">
         <h5>{{ organization_license }}</h5>
         <div id="{{ organization_license|slugify }}-cards" role="tablist" aria-multiselectable="true">
         {% for organization_card in organization_cards %}
-          <div class="card manage-card">
+          <div class="card manage-card" data-search="{{ organization_card.name }}">
 
             {# CARD HEADER #}
             <div class="card-header manage-card-header" role="tab" id="heading-{{ organization_card.id }}">
@@ -181,6 +195,11 @@
         </div>
       </div>
     {% endfor %}
+    {% if enable_search %}
+    <div id="organization-no-results" class="text-center mt-4 d-none">
+      <h4>No {{ page_title }} match your search.</h4>
+    </div>
+    {% endif %}
   </div>
 {% endblock %}
 
@@ -217,4 +236,7 @@
   {{ block.super }}
   <script src="{% static 'atcore/js/csrf.js' %}"></script>
   <script src="{% static 'atcore/js/delete_row.js' %}"></script>
+  {% if enable_search %}
+  <script src="{% static 'atcore/app_users/js/manage_organizations_filter.js' %}" type="text/javascript"></script>
+  {% endif %}
 {% endblock %}

--- a/tethysext/atcore/templates/atcore/app_users/manage_resources.html
+++ b/tethysext/atcore/templates/atcore/app_users/manage_resources.html
@@ -2,10 +2,40 @@
 
 {% load static tethys_gizmos %}
 
+{% block import_gizmos %}
+  {{ block.super }}
+  {% if use_datatable %}{% import_gizmo_dependency datatable_view %}{% endif %}
+{% endblock %}
+
 {% block app_content %}
   {% with tethys_app.namespace|add:':'|add:resource_slug as base_resource_href %}
     {% block buttons %}
     <div class="btn-toolbar top-action-btns float-end" role="toolbar" aria-label="Manage resources toolbar">
+      {% if enable_datatable %}
+        {% if use_datatable %}
+        {# Client-side: input wired to the DataTable in JS (no page reload). #}
+        <div class="me-2 d-flex align-items-center" role="search">
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-search"></i></span>
+            <input type="text" class="form-control" id="resource-search-input" placeholder="Search…" aria-label="Search {{ type_plural|lower }}">
+            <a class="btn btn-outline-secondary d-none" id="resource-search-clear" href="javascript:void(0);" title="Clear search"><i class="bi bi-x-lg"></i></a>
+          </div>
+        </div>
+        {% else %}
+        {# Server-side (grouped): full-page-reload search form. #}
+        <form class="me-2 d-flex align-items-center" method="get" role="search">
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-search"></i></span>
+            <input type="text" class="form-control" name="search" value="{{ search }}" placeholder="Search… (press Enter)" aria-label="Search {{ type_plural|lower }}">
+            {% if search %}
+            <a class="btn btn-outline-secondary" href="?sort_by={{ pagination_info.sort_by|urlencode }}&show={{ pagination_info.show }}" title="Clear search"><i class="bi bi-x-lg"></i></a>
+            {% endif %}
+          </div>
+          <input type="hidden" name="sort_by" value="{{ pagination_info.sort_by }}">
+          <input type="hidden" name="show" value="{{ pagination_info.show }}">
+        </form>
+        {% endif %}
+      {% endif %}
       {% if show_group_buttons and resources %}
       <div class="btn-group me-1">
         <a class="btn btn-outline-secondary manage-action-btn" role="button" href="javascript:void(0);" id="btn-expand-all" data-ts-toggle="table-row-expand-all" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Expand All"><i class="bi bi-chevron-expand"></i></a>
@@ -26,11 +56,30 @@
     <h1>{{ page_title }}</h1>
 
     {% if resources %}
+      {% if not use_datatable %}
       {% include "atcore/pagination_template.html" with pagination_info=pagination_info where="header"  %}
+      {% endif %}
       <div class="module-content">
-        <div id="resources-table" class="table-responsive table-sortable">
+        <div id="resources-table" class="table-responsive{% if not use_datatable %} table-sortable{% endif %}">
           <table class="table table-hover table-bottom-border" id="resource_table">
             <thead>
+              {% if use_datatable %}
+              {# SELECT #}
+              {% if show_select_column %}
+              <th class="no-sort"></th>
+              {% endif %}
+              <th>Name</th>
+              <th>Description</th>
+              {% if show_organizations_column %}
+              <th class="no-sort">Organizations</th>
+              {% endif %}
+              <th>Created By</th>
+              <th>Date Created</th>
+              {% if show_attributes %}
+              <th>Attributes</th>
+              {% endif %}
+              <th class="no-sort"></th>
+              {% else %}
               {# SELECT #}
               {% if show_select_column %}
               <th></th>
@@ -87,6 +136,7 @@
 
               {# BUTTONS HEADER #}
               <th></th>
+              {% endif %}
             </thead>
             <tbody>
               {# RESOURCE ROWS #}
@@ -104,9 +154,18 @@
           </table>
         </div>
       </div>
+      {% if not use_datatable %}
       {% include "atcore/pagination_template.html" with pagination_info=pagination_info where="footer" %}
+      {% endif %}
     {% else %}
-      {% if show_new_button %}
+      {% if search and not use_datatable %}
+        <div class="new-resource center-parent">
+          <div class="centered">
+            <h4>No {{ type_plural }} match “{{ search }}”</h4>
+            <a class="btn btn-outline-secondary" href="?sort_by={{ pagination_info.sort_by|urlencode }}&show={{ pagination_info.show }}">Clear search</a>
+          </div>
+        </div>
+      {% elif show_new_button %}
         {% block add_new_resource%}
           <div class="new-resource center-parent">
             <div class="centered">
@@ -219,7 +278,11 @@
   <script src="{% static 'atcore/js/csrf.js' %}" type="text/javascript"></script>
   <script src="{% static 'atcore/js/delete_row.js' %}"></script>
   <script src="{% static 'atcore/js/archive_row.js' %}"></script>
+  {% if use_datatable %}
+  <script src="{% static 'atcore/app_users/js/manage_resources_datatable.js' %}" type="text/javascript"></script>
+  {% else %}
   <script src="{% static 'atcore/app_users/js/sort.js' %}" type="text/javascript"></script>
+  {% endif %}
   <script src="{% static 'atcore/resources/group_resources.js' %}" type="text/javascript"></script>
   <script src="{% static 'atcore/js/table_row_collapse.js' %}" type="text/javascript"></script>
 {% endblock %}

--- a/tethysext/atcore/templates/atcore/app_users/manage_users.html
+++ b/tethysext/atcore/templates/atcore/app_users/manage_users.html
@@ -1,8 +1,22 @@
 {% extends base_template %}
 {% load static tethys_gizmos %}
 
+{% block import_gizmos %}
+  {{ block.super }}
+  {% if use_datatable %}{% import_gizmo_dependency datatable_view %}{% endif %}
+{% endblock %}
+
 {% block app_content %}
-  <div class="top-action-buttons float-end">
+  <div class="top-action-buttons float-end d-flex align-items-center">
+    {% if use_datatable and user_cards %}
+    <div class="me-2 d-flex align-items-center" role="search">
+      <div class="input-group">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
+        <input type="text" class="form-control" id="user-search-input" placeholder="Search…" aria-label="Search users">
+        <a class="btn btn-outline-secondary d-none" id="user-search-clear" href="javascript:void(0);" title="Clear search"><i class="bi bi-x-lg"></i></a>
+      </div>
+    </div>
+    {% endif %}
     {% if show_new_button %}
     <a class="btn btn-outline-secondary manage-action-btn btn-new" href="{% url tethys_app.namespace|add:':app_users_add_user' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="New"><i class="bi bi-plus-lg"></i></a>
     {% endif %}
@@ -11,18 +25,18 @@
     {% endif %}
   </div>
   <h1>{{ page_title|default:'User Accounts' }}</h1>
-  {% if user_cards %}
+  {% if user_cards and not use_datatable %}
   {% include "atcore/pagination_template.html" with pagination_info=pagination_info where="header" %}
   {% endif %}
-  <table class="table table-hover table-bottom-border">
+  <table class="table table-hover table-bottom-border" id="user_table">
     <thead>
       <tr>
         <th>Full Name / Username</th>
         <th>Active</th>
         <th>Role</th>
-        <th>Organizations</th>
+        <th class="no-sort">Organizations</th>
         {% if show_action_buttons %}
-        <th></th>
+        <th class="no-sort"></th>
         {% endif %}
       </tr>
     </thead>
@@ -56,11 +70,13 @@
         {% endif %}
       </tr>
       {% empty %}
+      {% if not use_datatable %}
       <tr><td colspan="5"><b>There are no users.</b></td></tr>
+      {% endif %}
       {% endfor %}
     </tbody>
   </table>
-  {% if user_cards %}
+  {% if user_cards and not use_datatable %}
   {% include "atcore/pagination_template.html" with pagination_info=pagination_info where="footer" %}
   {% endif %}
 
@@ -118,4 +134,7 @@
   <script src="{% static 'atcore/js/csrf.js' %}"></script>
   <script src="{% static 'atcore/js/delete_row.js' %}"></script>
   <script src="{% static 'atcore/js/remove_row.js' %}"></script>
+  {% if use_datatable %}
+  <script src="{% static 'atcore/app_users/js/manage_users_datatable.js' %}" type="text/javascript"></script>
+  {% endif %}
 {% endblock %}

--- a/tethysext/atcore/templates/atcore/components/resource_row.html
+++ b/tethysext/atcore/templates/atcore/components/resource_row.html
@@ -53,7 +53,7 @@
   {% endif %}
 
   {# DATE CREATED VALUE #}
-  <td class="date_created" data-id="{{ resource.date_created }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
+  <td class="date_created" data-id="{{ resource.date_created }}" data-order="{{ resource.date_created|date:'U' }}" onclick="window.document.location='{{ resource.info_href }}';" style="cursor: pointer;">
     {{ resource.date_created }} UTC
   </td>
 

--- a/tethysext/atcore/templates/atcore/pagination_template.html
+++ b/tethysext/atcore/templates/atcore/pagination_template.html
@@ -24,7 +24,7 @@ Requires a variable (whatever it may be called) that is an dictionary of the fol
     {% if where == 'footer' or where == 'header' and not x.hide_header_buttons %}
         {% if not x.hide_buttons %}
         <div>
-            <a role="button" href="?page={{ x.previous_page }}&show={{ x.show }}{% if x.sort_by %}&sort_by={{ x.sort_by }}{% endif %}" class="btn btn-outline-secondary{% if not x.enable_previous_button %} disabled {% endif %}">
+            <a role="button" href="?page={{ x.previous_page }}&show={{ x.show }}{% if x.sort_by %}&sort_by={{ x.sort_by }}{% endif %}{% if x.search %}&search={{ x.search|urlencode }}{% endif %}" class="btn btn-outline-secondary{% if not x.enable_previous_button %} disabled {% endif %}">
                 <i class="bi bi-chevron-left"></i> Previous
             </a>
         </div>
@@ -51,7 +51,7 @@ Requires a variable (whatever it may be called) that is an dictionary of the fol
     {% if where == 'footer' or where == 'header' and not x.hide_header_buttons %}
         {% if not x.hide_buttons %}
         <div>
-            <a role="button" href="?page={{ x.next_page }}&show={{ x.show }}{% if x.sort_by %}&sort_by={{ x.sort_by }}{% endif %}" class="btn btn-outline-secondary{% if not x.enable_next_button %} disabled {% endif %}">
+            <a role="button" href="?page={{ x.next_page }}&show={{ x.show }}{% if x.sort_by %}&sort_by={{ x.sort_by }}{% endif %}{% if x.search %}&search={{ x.search|urlencode }}{% endif %}" class="btn btn-outline-secondary{% if not x.enable_next_button %} disabled {% endif %}">
                 Next <i class="bi bi-chevron-right"></i>
             </a>
         </div>

--- a/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/app_users/manage_resources.py
@@ -120,7 +120,7 @@ class ManageResourcesTests(SqlAlchemyTestCase):
 
         mock_request = mock.MagicMock(spec=WSGIRequest)
         mock_request.user = self.django_user
-        mock_request.GET.get.side_effect = [1, '15', 'date_created:']
+        mock_request.GET.get.side_effect = [1, '15', 'date_created:', '']
 
         mock_get_resources.return_value = [self.resource]
 
@@ -210,7 +210,7 @@ class ManageResourcesTests(SqlAlchemyTestCase):
 
         mock_request = mock.MagicMock(spec=WSGIRequest)
         mock_request.user = self.django_user
-        mock_request.GET.get.side_effect = [1, None, None]
+        mock_request.GET.get.side_effect = [1, None, None, '']
 
         mock_get_resources.return_value = [self.resource]
 
@@ -273,6 +273,67 @@ class ManageResourcesTests(SqlAlchemyTestCase):
         self.assertEqual('atcore/app_users/base.html', render_args[0][0][2]['base_template'])
         self.assertTrue(render_args[0][0][2]['show_new_button'])
         self.assertTrue(render_args[0][0][2]['show_users_link'])
+
+    def test_resource_card_matches_search(self):
+        controller = MockManageResources()
+        card = {'name': 'Red Rock City', 'description': 'demo project', 'created_by': 'jjohnson'}
+        self.assertTrue(controller.resource_card_matches_search(card, 'red rock'))
+        self.assertTrue(controller.resource_card_matches_search(card, 'demo'))
+        self.assertTrue(controller.resource_card_matches_search(card, 'jjohnson'))
+        self.assertFalse(controller.resource_card_matches_search(card, 'nomatch'))
+
+    def test_resource_card_matches_search_handles_none_fields(self):
+        controller = MockManageResources()
+        card = {'name': None, 'description': None, 'created_by': None}
+        self.assertFalse(controller.resource_card_matches_search(card, 'anything'))
+
+    def test_filter_resource_cards_flat(self):
+        controller = MockManageResources()
+        cards = [
+            {'name': 'Alpha', 'description': '', 'created_by': '', 'children': []},
+            {'name': 'Beta', 'description': '', 'created_by': '', 'children': []},
+        ]
+        result = controller.filter_resource_cards(cards, 'alpha')
+        self.assertEqual(1, len(result))
+        self.assertEqual('Alpha', result[0]['name'])
+
+    def test_filter_resource_cards_keeps_parent_of_matching_child(self):
+        controller = MockManageResources()
+        cards = [{
+            'name': 'Parent', 'description': '', 'created_by': '',
+            'children': [
+                {'name': 'Matching Child', 'description': '', 'created_by': '', 'children': []},
+                {'name': 'Other Child', 'description': '', 'created_by': '', 'children': []},
+            ],
+        }]
+        result = controller.filter_resource_cards(cards, 'matching')
+        self.assertEqual(1, len(result))
+        self.assertEqual('Parent', result[0]['name'])
+        # The matching ancestor is kept, but its non-matching sibling subtree is pruned.
+        self.assertEqual(1, len(result[0]['children']))
+        self.assertEqual('Matching Child', result[0]['children'][0]['name'])
+
+    def test_filter_resource_cards_matching_parent_keeps_all_children(self):
+        controller = MockManageResources()
+        cards = [{
+            'name': 'Matching Parent', 'description': '', 'created_by': '',
+            'children': [
+                {'name': 'Child A', 'description': '', 'created_by': '', 'children': []},
+                {'name': 'Child B', 'description': '', 'created_by': '', 'children': []},
+            ],
+        }]
+        result = controller.filter_resource_cards(cards, 'matching')
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, len(result[0]['children']))
+
+    def test_filter_resource_cards_prunes_non_matching_branch(self):
+        controller = MockManageResources()
+        cards = [{
+            'name': 'Parent', 'description': '', 'created_by': '',
+            'children': [{'name': 'Child', 'description': '', 'created_by': '', 'children': []}],
+        }]
+        result = controller.filter_resource_cards(cards, 'zzz')
+        self.assertEqual(0, len(result))
 
     @mock.patch('tethys_apps.utilities.get_active_app')
     @mock.patch.object(ManageResources, 'perform_custom_delete_operations')


### PR DESCRIPTION
Primary changes in this Pull Request:

Adds search/filter capabilities for the following view:  Manage Users, Manage Organizations, and classes that derive off of the MangeResource view.

With the ManageResource view, the derived classes need to set the following variable:
`enable_datatable = True`

With the ManageResource view, a data table is used for instant client-side filtering when grouping isn't enabled (it filters as you type).  When grouping is enabled, server-side filtering is used for tree-away view that reloads (filters on Enter), preserving the grouping (the parent/child tree and pagination).  Text is shown, showing that the data is filtered ("Showing X (filtered from Y total)")

- 

Please review the checklist before submitting the Pull Request:

- [X] Pull request has a meaning full name (not just the commit message from of your last commit)
- [X] Code has been linted using flake8
- [X] All methods have accurate Google-Style Docstrings
- [X] 100% test coverage for new content
- [X] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints

Explain deviations from original design if applicable:

