### PR TITLE
Bugfix: datetime.datetime.utcnow() is deprecated in Python 3.12

### DIFF
--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import uuid
 
 from django.utils.text import slugify
@@ -29,7 +29,7 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
     name = Column(String)
     description = Column(String)
     type = Column(String)
-    date_created = Column(DateTime, default=datetime.datetime.utcnow)
+    date_created = Column(DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None))
     created_by = Column(String)
     status = Column(String)
     public = Column(Boolean, default=False)

--- a/tethysext/atcore/models/app_users/resource.py
+++ b/tethysext/atcore/models/app_users/resource.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import uuid
 
 from django.utils.text import slugify
@@ -29,7 +29,7 @@ class Resource(StatusMixin, AttributesMixin, UserLockMixin, SerializeMixin, AppU
     name = Column(String)
     description = Column(String)
     type = Column(String)
-    date_created = Column(DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None))
+    date_created = Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
     created_by = Column(String)
     status = Column(String)
     public = Column(Boolean, default=False)

--- a/tethysext/atcore/models/app_users/resource_workflow.py
+++ b/tethysext/atcore/models/app_users/resource_workflow.py
@@ -10,7 +10,7 @@ import uuid
 import param
 import logging
 
-import datetime as dt
+from datetime import datetime, UTC
 from abc import abstractmethod
 
 from django.shortcuts import reverse
@@ -73,7 +73,7 @@ class ResourceWorkflow(AppUsersBase, AttributesMixin, ResultsMixin, UserLockMixi
     type = Column(String)
 
     name = Column(String)
-    date_created = Column(DateTime, default=dt.datetime.utcnow)
+    date_created = Column(DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None))
     lock_when_finished = Column(Boolean, default=False)
     _attributes = Column(String)
     _user_lock = Column(String)

--- a/tethysext/atcore/models/app_users/resource_workflow.py
+++ b/tethysext/atcore/models/app_users/resource_workflow.py
@@ -10,7 +10,7 @@ import uuid
 import param
 import logging
 
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from abc import abstractmethod
 
 from django.shortcuts import reverse
@@ -73,7 +73,7 @@ class ResourceWorkflow(AppUsersBase, AttributesMixin, ResultsMixin, UserLockMixi
     type = Column(String)
 
     name = Column(String)
-    date_created = Column(DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None))
+    date_created = Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
     lock_when_finished = Column(Boolean, default=False)
     _attributes = Column(String)
     _user_lock = Column(String)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/base.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/base.py
@@ -6,7 +6,7 @@
 * Copyright: (c) Aquaveo 2018
 ********************************************************************************
 """
-import datetime as dt
+from datetime import datetime, UTC
 from unittest import mock
 from tethys_sdk.base import TethysController
 from tethysext.atcore.services.app_users.roles import Roles
@@ -45,7 +45,7 @@ class AppUsersResourceWorkflowControllerTests(SqlAlchemyTestCase):
         )
         self.session.add(self.user)
 
-        self.pre_created_date = dt.datetime.utcnow()
+        self.pre_created_date = datetime.now(UTC).replace(tzinfo=None)
 
         # create resource
         self.resource = Resource(
@@ -136,7 +136,7 @@ class AppUsersResourceControllerTests(SqlAlchemyTestCase):
         )
         self.session.add(self.user)
 
-        self.pre_created_date = dt.datetime.utcnow()
+        self.pre_created_date = datetime.now(UTC).replace(tzinfo=None)
 
         # create resource
         self.resource = Resource(

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/base.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/base.py
@@ -6,7 +6,7 @@
 * Copyright: (c) Aquaveo 2018
 ********************************************************************************
 """
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from unittest import mock
 from tethys_sdk.base import TethysController
 from tethysext.atcore.services.app_users.roles import Roles
@@ -45,7 +45,7 @@ class AppUsersResourceWorkflowControllerTests(SqlAlchemyTestCase):
         )
         self.session.add(self.user)
 
-        self.pre_created_date = datetime.now(UTC).replace(tzinfo=None)
+        self.pre_created_date = datetime.now(timezone.utc).replace(tzinfo=None)
 
         # create resource
         self.resource = Resource(
@@ -136,7 +136,7 @@ class AppUsersResourceControllerTests(SqlAlchemyTestCase):
         )
         self.session.add(self.user)
 
-        self.pre_created_date = datetime.now(UTC).replace(tzinfo=None)
+        self.pre_created_date = datetime.now(timezone.utc).replace(tzinfo=None)
 
         # create resource
         self.resource = Resource(

--- a/tethysext/atcore/tests/integrated_tests/mixins/file_collection_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/file_collection_mixin_tests.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import os
 import shutil
 import uuid
@@ -53,7 +53,7 @@ class FileCollectionMixinTests(SqlAlchemyTestCase):
         self.name = "test_resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.datetime.utcnow()
+        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
 
         # Test specific directories
         self.test_dir_name = self._testMethodName

--- a/tethysext/atcore/tests/integrated_tests/mixins/file_collection_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/file_collection_mixin_tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import os
 import shutil
 import uuid
@@ -53,7 +53,7 @@ class FileCollectionMixinTests(SqlAlchemyTestCase):
         self.name = "test_resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
+        self.creation_date = datetime.now(timezone.utc).replace(tzinfo=None)
 
         # Test specific directories
         self.test_dir_name = self._testMethodName

--- a/tethysext/atcore/tests/integrated_tests/mixins/file_collections_controller_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/file_collections_controller_mixin_tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from unittest import mock
 import os
 from pathlib import Path
@@ -61,7 +61,7 @@ class FileCollectionsControllerMixinTests(SqlAlchemyTestCase):
             name='Foo Resource',
             description='Foo Bar',
             created_by='foo',
-            date_created=datetime.now(UTC).replace(tzinfo=None),
+            date_created=datetime.now(timezone.utc).replace(tzinfo=None),
         )
 
         resource.set_attribute('files', [os.path.join(self.test_folder_path, 'dataset_data.zip')])

--- a/tethysext/atcore/tests/integrated_tests/mixins/file_collections_controller_mixin_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/mixins/file_collections_controller_mixin_tests.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 from unittest import mock
 import os
 from pathlib import Path
@@ -61,7 +61,7 @@ class FileCollectionsControllerMixinTests(SqlAlchemyTestCase):
             name='Foo Resource',
             description='Foo Bar',
             created_by='foo',
-            date_created=datetime.datetime.utcnow(),
+            date_created=datetime.now(UTC).replace(tzinfo=None),
         )
 
         resource.set_attribute('files', [os.path.join(self.test_folder_path, 'dataset_data.zip')])

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/resource_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/resource_tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import uuid
 from tethysext.atcore.models.app_users import Resource
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
@@ -20,7 +20,7 @@ class ResourceTests(SqlAlchemyTestCase):
         self.name = "A Resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
+        self.creation_date = datetime.now(timezone.utc).replace(tzinfo=None)
 
     def test_create_resource(self):
         resource = Resource(

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/resource_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/resource_tests.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import uuid
 from tethysext.atcore.models.app_users import Resource
 from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
@@ -20,7 +20,7 @@ class ResourceTests(SqlAlchemyTestCase):
         self.name = "A Resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.datetime.utcnow()
+        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
 
     def test_create_resource(self):
         resource = Resource(

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/spatial_resource_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/spatial_resource_tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 import json
 import uuid
 
@@ -35,7 +35,7 @@ class SpatialResourceTests(SqlAlchemyTestCase):
         self.name = "A Spatial Resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
+        self.creation_date = datetime.now(timezone.utc).replace(tzinfo=None)
         self.extent_dict = {
             'type': 'Polygon',
             'coordinates': [[

--- a/tethysext/atcore/tests/integrated_tests/models/app_users/spatial_resource_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/models/app_users/spatial_resource_tests.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, UTC
 import json
 import uuid
 
@@ -6,9 +6,9 @@ from sqlalchemy import func
 
 from tethysext.atcore.exceptions import InvalidSpatialResourceExtentTypeError
 from tethysext.atcore.models.app_users import SpatialResource
-from tethysext.atcore.tests.utilities.sqlalchemy_helpers import SqlAlchemyTestCase
-from tethysext.atcore.tests.utilities.sqlalchemy_helpers import setup_module_for_sqlalchemy_tests, \
-    tear_down_module_for_sqlalchemy_tests
+from tethysext.atcore.tests.utilities.sqlalchemy_helpers import (
+    SqlAlchemyTestCase, setup_module_for_sqlalchemy_tests, tear_down_module_for_sqlalchemy_tests
+)
 
 
 def setUpModule():
@@ -35,7 +35,7 @@ class SpatialResourceTests(SqlAlchemyTestCase):
         self.name = "A Spatial Resource"
         self.description = "Bad Description"
         self.status = "Processing"
-        self.creation_date = datetime.datetime.utcnow()
+        self.creation_date = datetime.now(UTC).replace(tzinfo=None)
         self.extent_dict = {
             'type': 'Polygon',
             'coordinates': [[


### PR DESCRIPTION
## Description

`datetime.datetime.utcnow()` is deprecated, which causes tests in [tribs-adapter](https://github.com/Aquaveo/tribs-adapter/blob/main/tests/intermediate_tests/test_resources/test_realization.py#L101) fail (it adds one more warning to `recwarn` so the assertion fails).

## Primary changes in this Pull Request:

  Change `datetime.datetime.utcnow()` to:

  ```python
  from datetime import datetime, timezone
  datetime.now(timezone.utc).replace(tzinfo=None)
  ```
    
    Note:
    - `datetime.utcnow()` doesn't have timezone information so I remove it from `datetime.now(UTC)` too
    - Don't use `from datetime import UTC; datetime.now(UTC)` because it's not compatible with Python 3.10


## Please review the checklist before submitting the Pull Request:

- [x] Pull request has a meaning full name (not just the commit message from of your last commit)
- [x] Code has been linted using flake8
- [x] All methods have accurate Google-Style Docstrings
- [x] 100% test coverage for new content
- [x] Tests for each common use case (please don't write one test that covers all use cases)
- [ ] Bonus: Use TypeHints
