### PR TITLE
Record condor job statuses per DAG node instead of appending to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,23 @@ node to die with `ImportError` after its work had succeeded.
 - The step's status store is now cleared and committed *before* the DAG is submitted
   rather than after. Nodes begin reporting as soon as DAGMan schedules them, so
   clearing afterwards could discard statuses that had already been committed.
-- A failure to record `STATUS_COMPLETE` is no longer reported as a node failure. It is
-  retried once on a fresh session and then logged, since the job's own work has already
-  succeeded at that point.
+- A failure to record `STATUS_COMPLETE` is no longer reported as a node failure, since the
+  job's own work has already succeeded at that point. Both the complete and failed status
+  writes now go through one path that retries on a fresh session and, if the status still
+  cannot be recorded, reports it through the module logger as well as stderr — a status
+  that never lands is the silent failure this change exists to prevent, so it needs to be
+  visible to whatever watches logs.
+- A row lock that times out under contention is retried on the same session. Only a
+  genuinely dead connection is invalidated, since `Session.invalidate()` discards
+  everything uncommitted on that session, not just the status write.
+- Submitting a step's job now detects failure by checking the recorded job status, not only
+  by catching exceptions. `TethysJob.execute()` records a failed submission as `ERR` rather
+  than raising, so an unreachable scheduler returns normally. On failure the step's previous
+  status, status message and job id are restored, so it is not left waiting on a job that
+  was never submitted. Downstream steps are reset only once submission has succeeded.
 
 ### Added
+
 
 - `get_step_statuses(step)` — the sanctioned way to read a step's sub-job statuses.
   Returns a list of status values and understands every shape written to date. Prefer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+Notable changes to `tethysext-atcore`.
+
+Versions are git tags, resolved at build time by `setuptools-scm`; there is no version
+string in the source tree. Only changes that affect consumers of this package are
+recorded here — behaviour changes, persisted-data shape changes, and additions or
+removals of public helpers.
+
+**Depend on a tag, not a commit.** Consumers that pin this package by raw commit SHA
+(for example as a git submodule tracking `master`) can land on a state between tags, in
+which a helper they import may not exist yet. That has already caused a downstream DAG
+node to die with `ImportError` after its work had succeeded.
+
+## Unreleased
+
+### Changed
+
+- A workflow step's condor sub-job statuses are now recorded per DAG node instead of
+  being appended to a flat list. Concurrent nodes previously overwrote one another
+  because the whole attributes document is re-serialized on every write, and a lost
+  `FAILED` made a failed workflow report success. The write now takes a row lock, and
+  keying by node also lets a retried node replace its own earlier status rather than
+  leaving a stale `FAILED` behind.
+- The authoritative statuses live under the `condor_job_statuses_by_node` step
+  attribute, as `{node_name: status}`.
+- The `condor_job_statuses` attribute is still written, as a plain list of the same
+  status values. It exists so that a rollback to 1.16.2 or earlier still finds the
+  shape it expects: that code calls `.append()` on the value and tests
+  `STATUS_FAILED in statuses`, both of which misbehave against a dict. Do not read it
+  directly.
+- Steps still holding the old flat list are read through positional `_legacy_N` keys.
+  Those entries carry no node identity, so a node that reported before the upgrade and
+  then retries will leave its earlier status behind; this is logged when it happens.
+  Draining in-flight DAGs before upgrading avoids it.
+- The step's status store is now cleared and committed *before* the DAG is submitted
+  rather than after. Nodes begin reporting as soon as DAGMan schedules them, so
+  clearing afterwards could discard statuses that had already been committed.
+- A failure to record `STATUS_COMPLETE` is no longer reported as a node failure. It is
+  retried once on a fresh session and then logged, since the job's own work has already
+  succeeded at that point.
+
+### Added
+
+- `get_step_statuses(step)` — the sanctioned way to read a step's sub-job statuses.
+  Returns a list of status values and understands every shape written to date. Prefer
+  it over reading either attribute directly.
+- `initialize_step_statuses(step)` — clears the store ahead of a submission.
+- `dag_node_name()` — resolves the running job's DAG node name from the job ad named by
+  `_CONDOR_JOB_AD`, with a process-unique fallback. Cached for the process.
+
+## 1.16.2
+
+- Fixed a 40P01 deadlock on `app_users_resources` caused by write-on-read attribute
+  getters (#182).
+
+## 1.16.1
+
+- Fixed use of `datetime.datetime.utcnow()`, deprecated in Python 3.12 (#181).

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -323,6 +323,9 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # Deal with locking
         self.handle_on_submit_locking(request, session, resource, step)
 
+        # Kept so the step can be put back if the submission below never happens.
+        previous_status = step.get_status(step.ROOT_STATUS_KEY)
+
         # Update status of the resource workflow step
         step.set_status(step.ROOT_STATUS_KEY, step.STATUS_WORKING)
         step.set_attribute(step.ATTR_STATUS_MESSAGE, None)
@@ -343,7 +346,18 @@ class SpatialCondorJobMWV(MapWorkflowView):
         session.commit()
 
         # Submit job
-        condor_job_manager.run_job()
+        try:
+            condor_job_manager.run_job()
+        except Exception:
+            # The state above is already committed, but nothing will ever report
+            # against it now. Leaving it would strand the step in WORKING, where
+            # the view tells the user to wait for a job that was never submitted
+            # and refuses to let them advance. Put it back so they can retry.
+            step.set_status(step.ROOT_STATUS_KEY, previous_status or step.STATUS_PENDING)
+            step.set_attribute('condor_job_id', None)
+            initialize_step_statuses(step)
+            session.commit()
+            raise
 
         return redirect(request.path)
 

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -14,6 +14,7 @@ from django.shortcuts import render, redirect
 from tethys_sdk.gizmos import JobsTable
 from tethysext.atcore.controllers.resource_workflows.map_workflows import MapWorkflowView
 from tethysext.atcore.models.resource_workflow_steps import SpatialCondorJobRWS
+from tethysext.atcore.services.resource_workflows.helpers import initialize_step_statuses
 from tethysext.atcore.services.workflow_manager.condor_workflow_manager import ResourceWorkflowCondorJobManager
 
 
@@ -322,9 +323,6 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # Deal with locking
         self.handle_on_submit_locking(request, session, resource, step)
 
-        # Submit job
-        condor_job_manager.run_job()
-
         # Update status of the resource workflow step
         step.set_status(step.ROOT_STATUS_KEY, step.STATUS_WORKING)
         step.set_attribute(step.ATTR_STATUS_MESSAGE, None)
@@ -332,13 +330,20 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # Save the job id to the step for later reference
         step.set_attribute('condor_job_id', job_id)
 
-        # Allow the step to track statuses on each "sub-job", keyed by node name
-        step.set_attribute('condor_job_statuses', {})
+        # Allow the step to track statuses on each "sub-job", keyed by node name.
+        # This has to be committed BEFORE the job is submitted: nodes start
+        # reporting as soon as DAGMan schedules them, and this write is an
+        # unlocked overwrite of the whole attributes document, so clearing it
+        # afterwards would discard statuses that had already been committed.
+        initialize_step_statuses(step)
 
         # Reset next steps
         step.workflow.reset_next_steps(step)
 
         session.commit()
+
+        # Submit job
+        condor_job_manager.run_job()
 
         return redirect(request.path)
 

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -404,13 +404,14 @@ class SpatialCondorJobMWV(MapWorkflowView):
         """
         workflow = getattr(condor_job_manager, 'workflow', None)
 
-        if workflow is None:
-            # Nothing to have submitted, and nothing running that a restore could orphan.
-            return False
-
         if getattr(workflow, 'cluster_id', 0):
             return True
 
+        # A missing workflow is not evidence of a failed submission. The manager
+        # initialises it to None and only populates it in prepare(), which run_job()
+        # always runs first, so None here means preparation did not happen rather than
+        # that the scheduler refused anything. Reporting failure for it would raise on
+        # paths that never attempted a submission at all.
         return getattr(workflow, '_status', None) not in ('ERR', 'ABT')
 
     @staticmethod

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -325,6 +325,7 @@ class SpatialCondorJobMWV(MapWorkflowView):
 
         # Kept so the step can be put back if the submission below never happens.
         previous_status = step.get_status(step.ROOT_STATUS_KEY)
+        previous_status_message = step.get_attribute(step.ATTR_STATUS_MESSAGE)
 
         # Update status of the resource workflow step
         step.set_status(step.ROOT_STATUS_KEY, step.STATUS_WORKING)
@@ -340,26 +341,80 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # afterwards would discard statuses that had already been committed.
         initialize_step_statuses(step)
 
-        # Reset next steps
-        step.workflow.reset_next_steps(step)
-
         session.commit()
 
         # Submit job
+        submission_error = None
+
         try:
             condor_job_manager.run_job()
-        except Exception:
-            # The state above is already committed, but nothing will ever report
-            # against it now. Leaving it would strand the step in WORKING, where
-            # the view tells the user to wait for a job that was never submitted
-            # and refuses to let them advance. Put it back so they can retry.
+        except Exception as e:
+            submission_error = e
+
+        # A raised exception is not the only way submission fails, and is not even the
+        # usual one: TethysJob.execute() catches everything the submit raises and records
+        # the job as ERR instead, so run_job() returns normally after a scheduler that
+        # could not be reached. The recorded status has to be checked as well.
+        if submission_error is None and not self.job_was_submitted(condor_job_manager):
+            submission_error = RuntimeError(
+                'The job for step {} was not accepted by the scheduler.'.format(step.id)
+            )
+
+        if submission_error is not None:
+            self.restore_step_after_failed_submission(
+                session, step, previous_status, previous_status_message,
+            )
+            raise submission_error
+
+        # Reset next steps only now that the job is really running. Doing it before
+        # submission would discard downstream results for a run that never started.
+        step.workflow.reset_next_steps(step)
+        session.commit()
+
+        return redirect(request.path)
+
+    @staticmethod
+    def job_was_submitted(condor_job_manager):
+        """
+        Whether the scheduler actually accepted the job.
+
+        TethysJob.execute() wraps the submit in a bare except that records the job as
+        ERR rather than re-raising, so the absence of an exception says nothing about
+        whether submission happened.
+
+        Args:
+            condor_job_manager(ResourceWorkflowCondorJobManager): The manager used to submit.
+
+        Returns:
+            bool: False only when the job is known to have failed to submit.
+        """
+        workflow = getattr(condor_job_manager, 'workflow', None)
+
+        return getattr(workflow, '_status', None) not in ('ERR', 'ABT')
+
+    @staticmethod
+    def restore_step_after_failed_submission(session, step, previous_status, previous_status_message):
+        """
+        Undoes the pre-submission state when no job will ever report against it.
+
+        Without this the step sits in WORKING waiting on a job that was never submitted,
+        and the view refuses to let the user advance.
+
+        Failure to restore is logged rather than raised: the caller is about to raise the
+        submission error, and replacing it with a cleanup error would hide the real cause.
+        """
+        try:
             step.set_status(step.ROOT_STATUS_KEY, previous_status or step.STATUS_PENDING)
+            step.set_attribute(step.ATTR_STATUS_MESSAGE, previous_status_message)
             step.set_attribute('condor_job_id', None)
             initialize_step_statuses(step)
             session.commit()
-            raise
-
-        return redirect(request.path)
+        except Exception:
+            session.rollback()
+            log.exception(
+                'Could not restore step %s after a failed job submission; it may be left in %s.',
+                step.id, step.STATUS_WORKING,
+            )
 
     def handle_on_submit_locking(self, request, session, resource, step):
         """

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -332,8 +332,8 @@ class SpatialCondorJobMWV(MapWorkflowView):
         # Save the job id to the step for later reference
         step.set_attribute('condor_job_id', job_id)
 
-        # Allow the step to track statuses on each "sub-job"
-        step.set_attribute('condor_job_statuses', [])
+        # Allow the step to track statuses on each "sub-job", keyed by node name
+        step.set_attribute('condor_job_statuses', {})
 
         # Reset next steps
         step.workflow.reset_next_steps(step)

--- a/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
+++ b/tethysext/atcore/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv.py
@@ -382,13 +382,34 @@ class SpatialCondorJobMWV(MapWorkflowView):
         ERR rather than re-raising, so the absence of an exception says nothing about
         whether submission happened.
 
+        A recorded ERR is not conclusive either. CondorBase._execute() submits and then
+        saves in two steps::
+
+            self.cluster_id = self.condor_object.submit(*args, **kwargs)
+            self.save()
+
+        and both are inside that same bare except, so a save that fails after a submit
+        that succeeded is recorded exactly like a scheduler that refused the job. Telling
+        the caller that a running DAG was never submitted is the more expensive mistake:
+        it would orphan the job and let the step's status document be rewritten without
+        the row lock every reporting node takes. The cluster id is assigned before the
+        save that can fail, so a non-zero value means the job is out there regardless of
+        what the status says.
+
         Args:
             condor_job_manager(ResourceWorkflowCondorJobManager): The manager used to submit.
 
         Returns:
-            bool: False only when the job is known to have failed to submit.
+            bool: False only when the job is known not to be running.
         """
         workflow = getattr(condor_job_manager, 'workflow', None)
+
+        if workflow is None:
+            # Nothing to have submitted, and nothing running that a restore could orphan.
+            return False
+
+        if getattr(workflow, 'cluster_id', 0):
+            return True
 
         return getattr(workflow, '_status', None) not in ('ERR', 'ABT')
 

--- a/tethysext/atcore/resources/resource_workflows/update_status.py
+++ b/tethysext/atcore/resources/resource_workflows/update_status.py
@@ -10,6 +10,7 @@
 import sys
 import traceback
 from tethysext.atcore.services.resource_workflows.decorators import workflow_step_job
+from tethysext.atcore.services.resource_workflows.helpers import get_step_statuses
 
 
 @workflow_step_job
@@ -21,7 +22,7 @@ def main(resource_db_session, model_db_session, resource, workflow, step, gs_pri
     # Write out needed files
     try:
         print('Updating status...')
-        job_statuses = step.get_attribute('condor_job_statuses')
+        job_statuses = get_step_statuses(step)
         print(job_statuses)
         if step.STATUS_FAILED in job_statuses:
             step.set_status(step.ROOT_STATUS_KEY, step.STATUS_FAILED)

--- a/tethysext/atcore/services/resource_workflows/decorators.py
+++ b/tethysext/atcore/services/resource_workflows/decorators.py
@@ -127,6 +127,42 @@ def workflow_step_job(job_func=None, *, db_engine_kwargs=None):
                 resource_db_session = None
                 ret_val = None
 
+                def record_status(status):
+                    """
+                    Records this node's status, never raising.
+
+                    set_step_status already retries a busy row and a dead connection.
+                    This adds the last resort: if the caller's session cannot be used at
+                    all, try once on a brand-new session from the same engine, and if
+                    even that fails, say so through the logger rather than only on
+                    stderr -- a status that never lands is the silent failure this whole
+                    mechanism exists to prevent, so it needs somewhere an operator can
+                    actually see it.
+                    """
+                    try:
+                        set_step_status(resource_db_session, step, status)
+                        return
+                    except Exception:
+                        log.warning(
+                            'Could not record %s for step %s on the job session; retrying on a fresh one.',
+                            status, args.resource_workflow_step_id, exc_info=True,
+                        )
+
+                    try:
+                        retry_session = sessionmaker(bind=resource_db_engine)()
+                        try:
+                            retry_step = retry_session.query(type(step)).get(step.id)
+                            set_step_status(retry_session, retry_step, status)
+                        finally:
+                            retry_session.close()
+                    except Exception:
+                        log.error(
+                            'Could not record %s for step %s. The status is lost; the workflow will '
+                            'not reflect what this node did.',
+                            status, args.resource_workflow_step_id, exc_info=True,
+                        )
+                        traceback.print_exc(file=sys.stderr)
+
                 try:
                     # Get the resource database session
                     engine_kwargs = db_engine_kwargs if db_engine_kwargs else {}
@@ -182,51 +218,17 @@ def workflow_step_job(job_func=None, *, db_engine_kwargs=None):
 
                     # Update step status
                     #
-                    # Deliberately guarded separately from the work above. The work
-                    # has already succeeded at this point, so a failure to record
-                    # that must not fall through to the handler below and be written
-                    # down as a node failure -- with the row lock the status write
-                    # now takes, contention is a real way for this to fail. Retry
-                    # once on a fresh session, then give up loudly rather than
-                    # reporting a success as a failure.
+                    # Deliberately guarded separately from the work above. The work has
+                    # already succeeded at this point, so a failure to record that must
+                    # not fall through to the handler below and be written down as a node
+                    # failure -- with the row lock the status write now takes, contention
+                    # is a real way for this to fail.
                     print('Updating status...')
-                    try:
-                        set_step_status(resource_db_session, step, step.STATUS_COMPLETE)
-                    except Exception:
-                        try:
-                            step_cls = type(step)
-                            step_id = step.id
-                            complete_session = sessionmaker(bind=resource_db_engine)()
-                            try:
-                                complete_step = complete_session.query(step_cls).get(step_id)
-                                set_step_status(complete_session, complete_step, step.STATUS_COMPLETE)
-                            finally:
-                                complete_session.close()
-                        except Exception:
-                            sys.stderr.write(
-                                'Could not record STATUS_COMPLETE for {0}; the job itself '
-                                'succeeded.\n'.format(args.resource_workflow_step_id)
-                            )
-                            traceback.print_exc(file=sys.stderr)
+                    record_status(step.STATUS_COMPLETE)
 
                 except Exception as e:
                     if step and resource_db_session:
-                        try:
-                            set_step_status(resource_db_session, step, step.STATUS_FAILED)
-                        except Exception:
-                            # Status write through the helper still failed; try one
-                            # more time on a brand-new session from the engine.
-                            try:
-                                step_cls = type(step)
-                                step_id = step.id
-                                fallback_session = sessionmaker(bind=resource_db_engine)()
-                                try:
-                                    fallback_step = fallback_session.query(step_cls).get(step_id)
-                                    set_step_status(fallback_session, fallback_step, step.STATUS_FAILED)
-                                finally:
-                                    fallback_session.close()
-                            except Exception:
-                                traceback.print_exc(file=sys.stderr)
+                        record_status(step.STATUS_FAILED)
                     sys.stderr.write('Error processing {0}'.format(args.resource_workflow_step_id))
                     traceback.print_exc(file=sys.stderr)
                     sys.stderr.write(repr(e))

--- a/tethysext/atcore/services/resource_workflows/decorators.py
+++ b/tethysext/atcore/services/resource_workflows/decorators.py
@@ -181,8 +181,33 @@ def workflow_step_job(job_func=None, *, db_engine_kwargs=None):
                     )
 
                     # Update step status
+                    #
+                    # Deliberately guarded separately from the work above. The work
+                    # has already succeeded at this point, so a failure to record
+                    # that must not fall through to the handler below and be written
+                    # down as a node failure -- with the row lock the status write
+                    # now takes, contention is a real way for this to fail. Retry
+                    # once on a fresh session, then give up loudly rather than
+                    # reporting a success as a failure.
                     print('Updating status...')
-                    set_step_status(resource_db_session, step, step.STATUS_COMPLETE)
+                    try:
+                        set_step_status(resource_db_session, step, step.STATUS_COMPLETE)
+                    except Exception:
+                        try:
+                            step_cls = type(step)
+                            step_id = step.id
+                            complete_session = sessionmaker(bind=resource_db_engine)()
+                            try:
+                                complete_step = complete_session.query(step_cls).get(step_id)
+                                set_step_status(complete_session, complete_step, step.STATUS_COMPLETE)
+                            finally:
+                                complete_session.close()
+                        except Exception:
+                            sys.stderr.write(
+                                'Could not record STATUS_COMPLETE for {0}; the job itself '
+                                'succeeded.\n'.format(args.resource_workflow_step_id)
+                            )
+                            traceback.print_exc(file=sys.stderr)
 
                 except Exception as e:
                     if step and resource_db_session:

--- a/tethysext/atcore/services/resource_workflows/helpers.py
+++ b/tethysext/atcore/services/resource_workflows/helpers.py
@@ -21,9 +21,9 @@ CONDOR_JOB_STATUSES_BY_NODE_KEY = 'condor_job_statuses_by_node'
 # (append raises, and `in` tests keys, so a real failure reports success).
 # Read through get_step_statuses() rather than reading this key directly.
 #
-# COMPAT (added 1.16.3, 2026-08-13): this mirror exists only to keep a rollback to
-# 1.16.2 or earlier safe. Safe to stop writing it once rolling back that far is no
-# longer supported. Note that downstream pins this package by commit SHA rather
+# COMPAT (added by PR #183, 2026-08-13): this mirror exists only to keep a rollback to
+# any release before PR #183 safe. Safe to stop writing it once rolling back that far
+# is no longer supported. Note that downstream pins this package by commit SHA rather
 # than by tag, so "earlier" is not bounded by the tag history alone.
 CONDOR_JOB_STATUSES_KEY = 'condor_job_statuses'
 
@@ -32,6 +32,9 @@ CONDOR_JOB_STATUSES_KEY = 'condor_job_statuses'
 # blocks every sibling's write until the backend is reaped, which can be minutes.
 # Exceeding it raises OperationalError, which set_step_status already retries.
 STATUS_LOCK_TIMEOUT_MS = 5000
+
+# Postgres SQLSTATE for "could not obtain lock", which is what lock_timeout raises.
+LOCK_NOT_AVAILABLE = '55P03'
 
 
 @lru_cache(maxsize=1)
@@ -75,13 +78,30 @@ def dag_node_name():
     return 'unknown_{}_{}'.format(os.getpid(), int(time.time()))
 
 
+def _is_lock_timeout(error):
+    """
+    Whether an OperationalError is Postgres giving up on a row lock (55P03).
+
+    Contention is not a broken connection, and the two want opposite handling:
+    a lock timeout means some other node held the row too long, and the
+    connection is still perfectly good.
+    """
+    return getattr(getattr(error, 'orig', None), 'pgcode', None) == LOCK_NOT_AVAILABLE
+
+
 def set_step_status(resource_db_session, step, status, node_name=None):
     """
     Records the status of one DAG node on the provided step.
 
-    Recovers once from a dead connection (e.g., the server terminated the
-    backend, the network dropped) by invalidating the bad connection,
-    opening a fresh session from the same engine, and retrying the write.
+    Retries once. A lock timeout is retried on the same session, since the
+    connection is healthy and only the row was busy. Anything else is treated as a
+    dead connection (the server terminated the backend, the network dropped) and
+    recovers by invalidating that connection, opening a fresh session from the same
+    engine, and retrying there.
+
+    CAUTION: the dead-connection path calls ``Session.invalidate()``, which discards
+    everything uncommitted on that session, not just this write. Commit or flush any
+    other pending work before calling this.
 
     Args:
         resource_db_session(sqlalchemy.orm.Session): Session bound to the step.
@@ -91,12 +111,21 @@ def set_step_status(resource_db_session, step, status, node_name=None):
             DAG node name of the running job.
     """
     node_name = node_name or dag_node_name()
+    contended = False
 
     try:
         _record_status(resource_db_session, step, status, node_name)
         return
-    except (OperationalError, PendingRollbackError):
-        pass
+    except (OperationalError, PendingRollbackError) as e:
+        contended = _is_lock_timeout(e)
+
+    if contended:
+        # Healthy connection, busy row. Keep the session and try again rather than
+        # throwing away a good connection during exactly the contention the row
+        # lock is there to create.
+        resource_db_session.rollback()
+        _record_status(resource_db_session, step, status, node_name)
+        return
 
     # Invalidate the dead connection so the pool evicts it, then retry once
     # on a brand-new session from the same engine.
@@ -147,16 +176,16 @@ def _status_dict(step):
 
     legacy = step.get_attribute(CONDOR_JOB_STATUSES_KEY)
 
-    # COMPAT (added 1.16.3, 2026-08-13): a build of this change that shipped before
+    # COMPAT (added by PR #183, 2026-08-13): a build of this change that shipped before
     # the per-node key existed wrote the dict here instead. Safe to delete once no
     # deployment is running a commit between e37cc4e and this one -- that range was
     # never tagged, so only pinned-by-SHA consumers can be on it.
     if isinstance(legacy, dict):
         return dict(legacy)
 
-    # COMPAT (added 1.16.3, 2026-08-13): the flat list written before statuses were
-    # keyed by node. Safe to delete once no ResourceWorkflowStep submitted before
-    # 1.16.3 can still report -- i.e. once every DAG in flight at that upgrade has
+    # COMPAT (added by PR #183, 2026-08-13): the flat list written before statuses were
+    # keyed by node. Safe to delete once no ResourceWorkflowStep submitted before PR #183
+    # shipped can still report -- i.e. once every DAG in flight at that upgrade has
     # finished. Deleting it earlier silently drops those steps' statuses.
     if isinstance(legacy, list):
         if legacy:

--- a/tethysext/atcore/services/resource_workflows/helpers.py
+++ b/tethysext/atcore/services/resource_workflows/helpers.py
@@ -1,12 +1,47 @@
 import argparse
+import os
+import time
 
 from sqlalchemy.exc import OperationalError, PendingRollbackError
 from sqlalchemy.orm import sessionmaker
 
+CONDOR_JOB_STATUSES_KEY = 'condor_job_statuses'
 
-def set_step_status(resource_db_session, step, status):
+
+def dag_node_name():
     """
-    Sets the status on the provided step to the provided status.
+    Name of the DAG node this process is running as.
+
+    DAGMan adds ``DAGNodeName`` to the job ad of every node it submits, and
+    HTCondor makes the job ad available to the running job in the file named by
+    the ``_CONDOR_JOB_AD`` environment variable. Reading it there means a job
+    can identify itself without any extra arguments being threaded through.
+
+    Returns:
+        str: the node name, or a process-unique placeholder if it cannot be
+            determined. The placeholder must be unique: a constant would make
+            every node overwrite the same entry.
+    """
+    job_ad_path = os.environ.get('_CONDOR_JOB_AD')
+
+    if job_ad_path:
+        try:
+            with open(job_ad_path, 'r') as job_ad:
+                for line in job_ad:
+                    key, separator, value = line.partition('=')
+                    if separator and key.strip() == 'DAGNodeName':
+                        name = value.strip().strip('"')
+                        if name:
+                            return name
+        except OSError:
+            pass
+
+    return 'unknown_{}_{}'.format(os.getpid(), int(time.time()))
+
+
+def set_step_status(resource_db_session, step, status, node_name=None):
+    """
+    Records the status of one DAG node on the provided step.
 
     Recovers once from a dead connection (e.g., the server terminated the
     backend, the network dropped) by invalidating the bad connection,
@@ -16,9 +51,13 @@ def set_step_status(resource_db_session, step, status):
         resource_db_session(sqlalchemy.orm.Session): Session bound to the step.
         step(ResourceWorkflowStep): The step to modify
         status(str): The status to set.
+        node_name(str, optional): Name of the reporting node. Defaults to the
+            DAG node name of the running job.
     """
+    node_name = node_name or dag_node_name()
+
     try:
-        _append_status(resource_db_session, step, status)
+        _record_status(resource_db_session, step, status, node_name)
         return
     except (OperationalError, PendingRollbackError):
         pass
@@ -32,17 +71,62 @@ def set_step_status(resource_db_session, step, status):
     fresh_session = sessionmaker(bind=engine)()
     try:
         fresh_step = fresh_session.query(step_cls).get(step_id)
-        _append_status(fresh_session, fresh_step, status)
+        _record_status(fresh_session, fresh_step, status, node_name)
     finally:
         fresh_session.close()
 
 
-def _append_status(session, step, status):
-    session.refresh(step)
-    step_statuses = step.get_attribute('condor_job_statuses')
-    step_statuses.append(status)
-    step.set_attribute('condor_job_statuses', step_statuses)
+def _record_status(session, step, status, node_name):
+    """
+    Writes one node's status into the step, keyed by node name.
+
+    The statuses are stored under a single key of the step's attributes, and
+    set_attribute re-serializes the whole attributes document, so this is a
+    read-modify-write of one column. Two nodes finishing at the same time would
+    otherwise each write their own version and lose the other's status, which
+    for a lost failure means the workflow reports success. The row is locked for
+    the duration to serialize concurrent nodes.
+
+    Keying by node name also makes a retried node overwrite its own earlier
+    status instead of leaving both, so a node that fails and then succeeds does
+    not leave a failure behind.
+    """
+    locked_step = (
+        session.query(type(step))
+        .populate_existing()
+        .with_for_update()
+        .filter_by(id=step.id)
+        .one()
+    )
+
+    statuses = locked_step.get_attribute(CONDOR_JOB_STATUSES_KEY) or {}
+
+    if isinstance(statuses, list):
+        # A step that was already running when this was deployed still holds the
+        # previous list form.
+        statuses = {'_legacy_{}'.format(i): s for i, s in enumerate(statuses)}
+
+    statuses[node_name] = status
+    locked_step.set_attribute(CONDOR_JOB_STATUSES_KEY, statuses)
     session.commit()
+
+
+def get_step_statuses(step):
+    """
+    The statuses reported by a step's DAG nodes.
+
+    Args:
+        step(ResourceWorkflowStep): The step to read.
+
+    Returns:
+        list: the reported statuses, from either the current or previous form.
+    """
+    statuses = step.get_attribute(CONDOR_JOB_STATUSES_KEY) or {}
+
+    if isinstance(statuses, dict):
+        return list(statuses.values())
+
+    return list(statuses)
 
 
 def parse_workflow_step_args():

--- a/tethysext/atcore/services/resource_workflows/helpers.py
+++ b/tethysext/atcore/services/resource_workflows/helpers.py
@@ -20,6 +20,11 @@ CONDOR_JOB_STATUSES_BY_NODE_KEY = 'condor_job_statuses_by_node'
 # and tests `STATUS_FAILED in statuses`, both of which misbehave against a dict
 # (append raises, and `in` tests keys, so a real failure reports success).
 # Read through get_step_statuses() rather than reading this key directly.
+#
+# COMPAT (added 1.16.3, 2026-08-13): this mirror exists only to keep a rollback to
+# 1.16.2 or earlier safe. Safe to stop writing it once rolling back that far is no
+# longer supported. Note that downstream pins this package by commit SHA rather
+# than by tag, so "earlier" is not bounded by the tag history alone.
 CONDOR_JOB_STATUSES_KEY = 'condor_job_statuses'
 
 # How long to wait for another node's status write before giving up. Without a
@@ -142,9 +147,17 @@ def _status_dict(step):
 
     legacy = step.get_attribute(CONDOR_JOB_STATUSES_KEY)
 
+    # COMPAT (added 1.16.3, 2026-08-13): a build of this change that shipped before
+    # the per-node key existed wrote the dict here instead. Safe to delete once no
+    # deployment is running a commit between e37cc4e and this one -- that range was
+    # never tagged, so only pinned-by-SHA consumers can be on it.
     if isinstance(legacy, dict):
         return dict(legacy)
 
+    # COMPAT (added 1.16.3, 2026-08-13): the flat list written before statuses were
+    # keyed by node. Safe to delete once no ResourceWorkflowStep submitted before
+    # 1.16.3 can still report -- i.e. once every DAG in flight at that upgrade has
+    # finished. Deleting it earlier silently drops those steps' statuses.
     if isinstance(legacy, list):
         if legacy:
             log.warning(

--- a/tethysext/atcore/services/resource_workflows/helpers.py
+++ b/tethysext/atcore/services/resource_workflows/helpers.py
@@ -1,13 +1,35 @@
 import argparse
+import logging
 import os
 import time
 
+from functools import lru_cache
+
+from sqlalchemy import text
 from sqlalchemy.exc import OperationalError, PendingRollbackError
 from sqlalchemy.orm import sessionmaker
 
+log = logging.getLogger(f'tethys.{__name__}')
+
+# Authoritative store for sub-job statuses: {node_name: status}.
+CONDOR_JOB_STATUSES_BY_NODE_KEY = 'condor_job_statuses_by_node'
+
+# A plain list of the same values, written alongside the authoritative store so
+# that code predating the per-node store still reads the shape it expects. That
+# matters for a rollback: the previous implementation does `statuses.append(...)`
+# and tests `STATUS_FAILED in statuses`, both of which misbehave against a dict
+# (append raises, and `in` tests keys, so a real failure reports success).
+# Read through get_step_statuses() rather than reading this key directly.
 CONDOR_JOB_STATUSES_KEY = 'condor_job_statuses'
 
+# How long to wait for another node's status write before giving up. Without a
+# bound, a node killed by HTCondor between taking the row lock and committing
+# blocks every sibling's write until the backend is reaped, which can be minutes.
+# Exceeding it raises OperationalError, which set_step_status already retries.
+STATUS_LOCK_TIMEOUT_MS = 5000
 
+
+@lru_cache(maxsize=1)
 def dag_node_name():
     """
     Name of the DAG node this process is running as.
@@ -16,6 +38,11 @@ def dag_node_name():
     HTCondor makes the job ad available to the running job in the file named by
     the ``_CONDOR_JOB_AD`` environment variable. Reading it there means a job
     can identify itself without any extra arguments being threaded through.
+
+    The result is cached for the life of the process. A job reports its status
+    more than once (see decorators.workflow_step_job), and the fallback below
+    embeds the current time, so recomputing it would hand the same node two
+    different keys and defeat the point of keying by node.
 
     Returns:
         str: the node name, or a process-unique placeholder if it cannot be
@@ -33,9 +60,13 @@ def dag_node_name():
                         name = value.strip().strip('"')
                         if name:
                             return name
+            log.warning('No DAGNodeName in job ad %s; falling back to a generated node name.', job_ad_path)
         except OSError:
-            pass
+            log.warning('Could not read job ad %s; falling back to a generated node name.', job_ad_path, exc_info=True)
 
+    # Unique per process, so two nodes never collide, but NOT stable across
+    # processes: a node retried on another host cannot overwrite its earlier
+    # entry and will leave both behind.
     return 'unknown_{}_{}'.format(os.getpid(), int(time.time()))
 
 
@@ -76,6 +107,73 @@ def set_step_status(resource_db_session, step, status, node_name=None):
         fresh_session.close()
 
 
+def _set_lock_timeout(session):
+    """
+    Bounds how long the row lock in _record_status will be waited for.
+
+    Postgres only; other backends are left at their defaults rather than being
+    given a statement they would reject. SET LOCAL applies to the surrounding
+    transaction only, so it does not leak to other users of the connection.
+    """
+    bind = session.get_bind()
+
+    if bind is None or bind.dialect.name != 'postgresql':
+        return
+
+    session.execute(text("SET LOCAL lock_timeout = '{}ms'".format(STATUS_LOCK_TIMEOUT_MS)))
+
+
+def _status_dict(step):
+    """
+    A step's node statuses as a dict, whatever shape they are stored in.
+
+    Reads the authoritative per-node store when present. Otherwise falls back to
+    the shapes written by earlier releases: the original flat list, and the dict
+    that a pre-release build of this change wrote under the old key. Entries from
+    the flat list carry no node identity, so they are given positional keys.
+
+    Anything else (a string, a number, nothing at all) yields an empty dict
+    rather than being coerced, so a corrupt value cannot masquerade as statuses.
+    """
+    statuses = step.get_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY)
+
+    if isinstance(statuses, dict):
+        return dict(statuses)
+
+    legacy = step.get_attribute(CONDOR_JOB_STATUSES_KEY)
+
+    if isinstance(legacy, dict):
+        return dict(legacy)
+
+    if isinstance(legacy, list):
+        if legacy:
+            log.warning(
+                'Step %s still holds %d status(es) in the pre-node-name format. They cannot be '
+                'attributed to a node, so a node that reported before the upgrade and then retries '
+                'will leave its earlier status behind.',
+                step.id, len(legacy),
+            )
+        return {'_legacy_{}'.format(i): s for i, s in enumerate(legacy)}
+
+    return {}
+
+
+def initialize_step_statuses(step):
+    """
+    Clears a step's node statuses ahead of a new job submission.
+
+    Call this BEFORE the DAG is submitted. Nodes begin reporting as soon as
+    DAGMan schedules them, and this write is an unlocked overwrite of the whole
+    attributes document, so clearing after submission can discard statuses that
+    have already been committed.
+
+    Args:
+        step(ResourceWorkflowStep): The step to reset.
+    """
+    step.set_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY, {})
+    step.set_attribute(CONDOR_JOB_STATUSES_KEY, [])
+
+
 def _record_status(session, step, status, node_name):
     """
     Writes one node's status into the step, keyed by node name.
@@ -90,7 +188,12 @@ def _record_status(session, step, status, node_name):
     Keying by node name also makes a retried node overwrite its own earlier
     status instead of leaving both, so a node that fails and then succeeds does
     not leave a failure behind.
+
+    Both the per-node store and the legacy list mirror are written, so a release
+    rolled back to code that predates the per-node store still finds a list.
     """
+    _set_lock_timeout(session)
+
     locked_step = (
         session.query(type(step))
         .populate_existing()
@@ -99,15 +202,11 @@ def _record_status(session, step, status, node_name):
         .one()
     )
 
-    statuses = locked_step.get_attribute(CONDOR_JOB_STATUSES_KEY) or {}
-
-    if isinstance(statuses, list):
-        # A step that was already running when this was deployed still holds the
-        # previous list form.
-        statuses = {'_legacy_{}'.format(i): s for i, s in enumerate(statuses)}
-
+    statuses = _status_dict(locked_step)
     statuses[node_name] = status
-    locked_step.set_attribute(CONDOR_JOB_STATUSES_KEY, statuses)
+
+    locked_step.set_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY, statuses)
+    locked_step.set_attribute(CONDOR_JOB_STATUSES_KEY, list(statuses.values()))
     session.commit()
 
 
@@ -119,14 +218,9 @@ def get_step_statuses(step):
         step(ResourceWorkflowStep): The step to read.
 
     Returns:
-        list: the reported statuses, from either the current or previous form.
+        list: the reported statuses, in whatever shape they are stored.
     """
-    statuses = step.get_attribute(CONDOR_JOB_STATUSES_KEY) or {}
-
-    if isinstance(statuses, dict):
-        return list(statuses.values())
-
-    return list(statuses)
+    return list(_status_dict(step).values())
 
 
 def parse_workflow_step_args():

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -400,7 +400,10 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         # assertion below cannot tell a real restore from the fallback firing.
         self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_COMPLETE)
         self.step.set_attribute(self.step.ATTR_STATUS_MESSAGE, 'previous message')
-        self.step.set_attribute('condor_job_id', 'previous-job-id')
+        # No condor_job_id: a previous id sends run_job() down the delete-previous-job
+        # branch, which chdirs into a workspace this test has no reason to create. The
+        # pre-submission block sets the id from the prepared job anyway, so asserting it
+        # is None below still proves the restore ran.
 
         session = mock.MagicMock()
         self.step.workflow = mock.MagicMock()
@@ -470,7 +473,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         mock_run_job.return_value = str(self.workflow.id)
 
         self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_COMPLETE)
-        self.step.set_attribute('condor_job_id', 'previous-job-id')
+        # See the note in test_run_job__submission_failure_does_not_strand_the_step: a
+        # previous condor_job_id would route through the delete-previous-job branch.
 
         session = mock.MagicMock()
         self.step.workflow = mock.MagicMock()

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -20,6 +20,7 @@ from tethysext.atcore.controllers.resource_workflows.workflow_view import Resour
 from tethysext.atcore.models.resource_workflow_steps.spatial_dataset_rws import SpatialDatasetRWS
 from tethysext.atcore.models.app_users import Resource
 from tethysext.atcore.services.map_manager import MapManagerBase
+from tethysext.atcore.services.resource_workflows.helpers import CONDOR_JOB_STATUSES_BY_NODE_KEY
 from tethysext.atcore.services.workflow_manager.condor_workflow_manager import ResourceWorkflowCondorJobManager
 from tethysext.atcore.tests.factories.django_user import UserFactory
 from tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.workflow_view_test_case import \
@@ -362,6 +363,67 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
 
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
+
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.mixins.WorkflowViewMixin.get_step')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'prepare')
+    @mock.patch.object(SpatialCondorJobMWV, 'get_working_directory')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
+    def test_run_job__submission_failure_does_not_strand_the_step(
+            self, mock_model_db, mock_get_map_manager, mock_get_working_dir, mock_prepare, mock_run_job,
+            mock_get_step, mock_is_read_only):
+        """The step state is committed before submission, so a failed submit has to undo it.
+
+        Otherwise the step sits in WORKING waiting on a job that was never submitted, and the
+        view refuses to let the user advance.
+        """
+        map_manager = mock.MagicMock(
+            spec=MapManagerBase,
+            spatial_manager=mock.MagicMock(
+                gs_engine=mock.MagicMock(
+                    username='Faxy', password='Bear',
+                    endpoint='http://localhost:8181/geoserver/rest',
+                    public_endpoint='http://localhost:8181/geoserver/rest',
+                )
+            )
+        )
+        mock_model_db.return_value = mock.MagicMock(db_url='fake_db_url')
+        mock_get_map_manager.return_value = map_manager
+        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        mock_prepare.return_value = self.workflow.id
+        mock_run_job.side_effect = RuntimeError('scheduler unreachable')
+        mock_get_step.return_value = self.step
+
+        self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_PENDING)
+        self.step.set_attribute('condor_job_id', None)
+
+        session = mock.MagicMock()
+        self.step.workflow = mock.MagicMock()
+        self.step.workflow.resource = self.resource
+        self.request.user = UserFactory()
+        self.request.POST['run-submit'] = True
+        self.request.POST['rerun-submit'] = True
+        self.step.options['scheduler'] = 'my_schedule'
+        self.step.options['jobs'] = [{
+            'name': 'base_scenario',
+            'condorpy_template_name': 'vanilla_transfer_files',
+            'remote_input_files': [None],
+            'attributes': {
+                'executable': 'run_base_scenario.py',
+                'transfer_output_files': ['gssha_files', 'base_ohl_series.json'],
+            },
+        }]
+
+        with self.assertRaises(RuntimeError):
+            SpatialCondorJobMWV().run_job(
+                self.request, session, self.resource, self.workflow.id, self.step.id,
+            )
+
+        self.assertEqual(self.step.STATUS_PENDING, self.step.get_status(self.step.ROOT_STATUS_KEY))
+        self.assertIsNone(self.step.get_attribute('condor_job_id'))
+        self.assertEqual({}, self.step.get_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY))
 
     @mock.patch.object(AppUsersViewMixin, 'get_app')
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -396,8 +396,13 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         mock_run_job.side_effect = RuntimeError('scheduler unreachable')
         mock_get_step.return_value = self.step
 
-        self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_PENDING)
-        self.step.set_attribute('condor_job_id', None)
+        # Distinct from STATUS_PENDING, which is the restore's fallback -- otherwise the
+        # assertion below cannot tell a real restore from the fallback firing.
+        self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_COMPLETE)
+        self.step.set_attribute(self.step.ATTR_STATUS_MESSAGE, 'previous message')
+        self.step.set_attribute('condor_job_id', 'previous-job-id')
+        # Non-empty, so the assertion that it was cleared cannot pass vacuously.
+        self.step.set_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY, {'stale_node': 'Failed'})
 
         session = mock.MagicMock()
         self.step.workflow = mock.MagicMock()
@@ -421,9 +426,92 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
                 self.request, session, self.resource, self.workflow.id, self.step.id,
             )
 
-        self.assertEqual(self.step.STATUS_PENDING, self.step.get_status(self.step.ROOT_STATUS_KEY))
+        self.assertEqual(self.step.STATUS_COMPLETE, self.step.get_status(self.step.ROOT_STATUS_KEY))
+        self.assertEqual('previous message', self.step.get_attribute(self.step.ATTR_STATUS_MESSAGE))
         self.assertIsNone(self.step.get_attribute('condor_job_id'))
         self.assertEqual({}, self.step.get_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY))
+        # Downstream results must survive a run that never started.
+        self.step.workflow.reset_next_steps.assert_not_called()
+
+    @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.mixins.WorkflowViewMixin.get_step')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
+    @mock.patch.object(ResourceWorkflowCondorJobManager, 'prepare')
+    @mock.patch.object(SpatialCondorJobMWV, 'get_working_directory')
+    @mock.patch.object(MapView, 'get_map_manager')
+    @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
+    def test_run_job__submission_recorded_as_err_is_treated_as_failure(
+            self, mock_model_db, mock_get_map_manager, mock_get_working_dir, mock_prepare, mock_run_job,
+            mock_get_step, mock_is_read_only):
+        """TethysJob.execute() swallows submission errors and records ERR without raising.
+
+        Catching exceptions alone therefore misses the ordinary failure, which is what left
+        the step stranded in WORKING.
+        """
+        map_manager = mock.MagicMock(
+            spec=MapManagerBase,
+            spatial_manager=mock.MagicMock(
+                gs_engine=mock.MagicMock(
+                    username='Faxy', password='Bear',
+                    endpoint='http://localhost:8181/geoserver/rest',
+                    public_endpoint='http://localhost:8181/geoserver/rest',
+                )
+            )
+        )
+        mock_model_db.return_value = mock.MagicMock(db_url='fake_db_url')
+        mock_get_map_manager.return_value = map_manager
+        mock_get_working_dir.return_value = os.path.join(self.working_dir_path, 'working_dir')
+        mock_prepare.return_value = self.workflow.id
+        mock_get_step.return_value = self.step
+
+        # run_job returns normally, exactly as it does when execute() absorbed the error.
+        mock_run_job.return_value = str(self.workflow.id)
+
+        self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_COMPLETE)
+        self.step.set_attribute('condor_job_id', 'previous-job-id')
+
+        session = mock.MagicMock()
+        self.step.workflow = mock.MagicMock()
+        self.step.workflow.resource = self.resource
+        self.request.user = UserFactory()
+        self.request.POST['run-submit'] = True
+        self.request.POST['rerun-submit'] = True
+        self.step.options['scheduler'] = 'my_schedule'
+        self.step.options['jobs'] = [{
+            'name': 'base_scenario',
+            'condorpy_template_name': 'vanilla_transfer_files',
+            'remote_input_files': [None],
+            'attributes': {
+                'executable': 'run_base_scenario.py',
+                'transfer_output_files': ['gssha_files', 'base_ohl_series.json'],
+            },
+        }]
+
+        with mock.patch.object(SpatialCondorJobMWV, 'job_was_submitted', return_value=False):
+            with self.assertRaises(RuntimeError):
+                SpatialCondorJobMWV().run_job(
+                    self.request, session, self.resource, self.workflow.id, self.step.id,
+                )
+
+        self.assertEqual(self.step.STATUS_COMPLETE, self.step.get_status(self.step.ROOT_STATUS_KEY))
+        self.assertIsNone(self.step.get_attribute('condor_job_id'))
+        self.step.workflow.reset_next_steps.assert_not_called()
+
+    def test_job_was_submitted(self):
+        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='ERR'))))
+        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='ABT'))))
+        self.assertTrue(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='SUB'))))
+
+    def test_restore_step_after_failed_submission__commit_failure_is_logged_not_raised(self):
+        """The caller is about to raise the submission error; cleanup must not replace it."""
+        session = mock.MagicMock()
+        session.commit.side_effect = RuntimeError('database gone')
+
+        SpatialCondorJobMWV.restore_step_after_failed_submission(
+            session, self.step, self.step.STATUS_COMPLETE, 'previous message',
+        )
+
+        session.rollback.assert_called_once()
 
     @mock.patch.object(AppUsersViewMixin, 'get_app')
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -20,7 +20,6 @@ from tethysext.atcore.controllers.resource_workflows.workflow_view import Resour
 from tethysext.atcore.models.resource_workflow_steps.spatial_dataset_rws import SpatialDatasetRWS
 from tethysext.atcore.models.app_users import Resource
 from tethysext.atcore.services.map_manager import MapManagerBase
-from tethysext.atcore.services.resource_workflows.helpers import CONDOR_JOB_STATUSES_BY_NODE_KEY
 from tethysext.atcore.services.workflow_manager.condor_workflow_manager import ResourceWorkflowCondorJobManager
 from tethysext.atcore.tests.factories.django_user import UserFactory
 from tethysext.atcore.tests.integrated_tests.controllers.resource_workflows.workflow_view_test_case import \
@@ -364,6 +363,7 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.assertIsInstance(ret, HttpResponseRedirect)
         self.assertEqual(self.request.path, ret.url)
 
+    @mock.patch.object(AppUsersViewMixin, 'get_app')
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
     @mock.patch('tethysext.atcore.controllers.resource_workflows.mixins.WorkflowViewMixin.get_step')
     @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
@@ -373,7 +373,7 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
     @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
     def test_run_job__submission_failure_does_not_strand_the_step(
             self, mock_model_db, mock_get_map_manager, mock_get_working_dir, mock_prepare, mock_run_job,
-            mock_get_step, mock_is_read_only):
+            mock_get_step, mock_is_read_only, mock_get_app):
         """The step state is committed before submission, so a failed submit has to undo it.
 
         Otherwise the step sits in WORKING waiting on a job that was never submitted, and the
@@ -401,8 +401,6 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.step.set_status(self.step.ROOT_STATUS_KEY, self.step.STATUS_COMPLETE)
         self.step.set_attribute(self.step.ATTR_STATUS_MESSAGE, 'previous message')
         self.step.set_attribute('condor_job_id', 'previous-job-id')
-        # Non-empty, so the assertion that it was cleared cannot pass vacuously.
-        self.step.set_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY, {'stale_node': 'Failed'})
 
         session = mock.MagicMock()
         self.step.workflow = mock.MagicMock()
@@ -426,13 +424,17 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
                 self.request, session, self.resource, self.workflow.id, self.step.id,
             )
 
+        # Each of these is set by the pre-submission block to something different, so they
+        # all fail if the restore is removed. The status store is deliberately not asserted
+        # on: the pre-submission block clears it unconditionally, so its final value is the
+        # same whether the restore ran or not.
         self.assertEqual(self.step.STATUS_COMPLETE, self.step.get_status(self.step.ROOT_STATUS_KEY))
         self.assertEqual('previous message', self.step.get_attribute(self.step.ATTR_STATUS_MESSAGE))
         self.assertIsNone(self.step.get_attribute('condor_job_id'))
-        self.assertEqual({}, self.step.get_attribute(CONDOR_JOB_STATUSES_BY_NODE_KEY))
         # Downstream results must survive a run that never started.
         self.step.workflow.reset_next_steps.assert_not_called()
 
+    @mock.patch.object(AppUsersViewMixin, 'get_app')
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)
     @mock.patch('tethysext.atcore.controllers.resource_workflows.mixins.WorkflowViewMixin.get_step')
     @mock.patch.object(ResourceWorkflowCondorJobManager, 'run_job')
@@ -442,7 +444,7 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
     @mock.patch('tethysext.atcore.services.workflow_manager.condor_workflow_manager.ModelDatabase')
     def test_run_job__submission_recorded_as_err_is_treated_as_failure(
             self, mock_model_db, mock_get_map_manager, mock_get_working_dir, mock_prepare, mock_run_job,
-            mock_get_step, mock_is_read_only):
+            mock_get_step, mock_is_read_only, mock_get_app):
         """TethysJob.execute() swallows submission errors and records ERR without raising.
 
         Catching exceptions alone therefore misses the ordinary failure, which is what left
@@ -498,11 +500,27 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         self.step.workflow.reset_next_steps.assert_not_called()
 
     def test_job_was_submitted(self):
-        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='ERR'))))
-        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='ABT'))))
-        self.assertTrue(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=mock.MagicMock(_status='SUB'))))
+        def manager(**workflow_attrs):
+            workflow_attrs.setdefault('cluster_id', 0)
+            return mock.MagicMock(workflow=mock.MagicMock(**workflow_attrs))
 
-    def test_restore_step_after_failed_submission__commit_failure_is_logged_not_raised(self):
+        self.assertTrue(SpatialCondorJobMWV.job_was_submitted(manager(_status='SUB')))
+        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(manager(_status='ERR')))
+        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(manager(_status='ABT')))
+
+    def test_job_was_submitted__cluster_id_wins_over_a_recorded_error(self):
+        """CondorBase._execute() submits and then saves; only the save has to fail for the
+        job to be recorded ERR while the DAG is genuinely running. Reporting that as
+        'not submitted' would orphan it."""
+        manager = mock.MagicMock(workflow=mock.MagicMock(_status='ERR', cluster_id=4211))
+
+        self.assertTrue(SpatialCondorJobMWV.job_was_submitted(manager))
+
+    def test_job_was_submitted__no_workflow_fails_closed(self):
+        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=None)))
+
+    @mock.patch('tethysext.atcore.controllers.resource_workflows.map_workflows.spatial_condor_job_mwv.log')
+    def test_restore_step_after_failed_submission__commit_failure_is_logged_not_raised(self, mock_log):
         """The caller is about to raise the submission error; cleanup must not replace it."""
         session = mock.MagicMock()
         session.commit.side_effect = RuntimeError('database gone')
@@ -512,6 +530,8 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
         )
 
         session.rollback.assert_called_once()
+        # A step that could not be restored is left mid-run; that has to be visible.
+        mock_log.exception.assert_called_once()
 
     @mock.patch.object(AppUsersViewMixin, 'get_app')
     @mock.patch.object(ResourceWorkflowView, 'is_read_only', return_value=False)

--- a/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/controllers/resource_workflows/map_workflows/spatial_condor_job_mwv_tests.py
@@ -516,8 +516,10 @@ class SpatialCondorJobMwvTests(WorkflowViewTestCase):
 
         self.assertTrue(SpatialCondorJobMWV.job_was_submitted(manager))
 
-    def test_job_was_submitted__no_workflow_fails_closed(self):
-        self.assertFalse(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=None)))
+    def test_job_was_submitted__no_workflow_is_not_a_failed_submission(self):
+        """The manager holds workflow=None until prepare() populates it, so None means
+        preparation did not run -- not that the scheduler refused the job."""
+        self.assertTrue(SpatialCondorJobMWV.job_was_submitted(mock.MagicMock(workflow=None)))
 
     @mock.patch('tethysext.atcore.controllers.resource_workflows.map_workflows.spatial_condor_job_mwv.log')
     def test_restore_step_after_failed_submission__commit_failure_is_logged_not_raised(self, mock_log):

--- a/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
@@ -7,99 +7,241 @@
 ********************************************************************************
 """
 from unittest import mock
+import os
+import tempfile
 import unittest
 from sqlalchemy.exc import OperationalError, PendingRollbackError
 from tethysext.atcore.services.resource_workflows import helpers
 from tethysext.atcore.models.app_users import ResourceWorkflowStep
 from argparse import Namespace
 
+NODE = 'original_scenario_2yr'
+
+
+def bind_locking_query(session, step):
+    """Point the row-locking query chain of a mocked session at the given step."""
+    query = session.query.return_value
+    query.populate_existing.return_value.with_for_update.return_value \
+        .filter_by.return_value.one.return_value = step
+    return query.populate_existing.return_value.with_for_update.return_value \
+        .filter_by.return_value
+
 
 class HelpersTests(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.step = ResourceWorkflowStep(name='name1', help='help1', order=1)
 
     def tearDown(self):
         pass
 
     def test_set_step_status(self):
         session = mock.MagicMock()
-        step = ResourceWorkflowStep(name='name1', help='help1', order=1)
-        step.attributes = {'condor_job_statuses': [step.STATUS_PENDING]}
+        self.step.attributes = {'condor_job_statuses': {}}
+        bind_locking_query(session, self.step)
 
-        helpers.set_step_status(session, step, step.STATUS_COMPLETE)
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
 
-        self.assertEqual([step.STATUS_PENDING, step.STATUS_COMPLETE], step.get_attribute('condor_job_statuses'))
+        self.assertEqual(
+            {NODE: self.step.STATUS_COMPLETE},
+            self.step.get_attribute('condor_job_statuses'),
+        )
+        session.commit.assert_called_once()
+
+    def test_set_step_status_locks_the_row(self):
+        session = mock.MagicMock()
+        self.step.attributes = {'condor_job_statuses': {}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        session.query.return_value.populate_existing.return_value \
+            .with_for_update.assert_called_once()
+
+    def test_set_step_status_keeps_other_nodes(self):
+        session = mock.MagicMock()
+        self.step.attributes = {'condor_job_statuses': {'other_node': self.step.STATUS_COMPLETE}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
+
+        self.assertEqual(
+            {'other_node': self.step.STATUS_COMPLETE, NODE: self.step.STATUS_FAILED},
+            self.step.get_attribute('condor_job_statuses'),
+        )
+
+    def test_set_step_status_retry_overwrites_previous_status(self):
+        """A node that fails and then succeeds must not leave the failure behind."""
+        session = mock.MagicMock()
+        self.step.attributes = {'condor_job_statuses': {}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        self.assertEqual(
+            {NODE: self.step.STATUS_COMPLETE},
+            self.step.get_attribute('condor_job_statuses'),
+        )
+        self.assertNotIn(self.step.STATUS_FAILED, helpers.get_step_statuses(self.step))
+
+    def test_set_step_status_migrates_legacy_list(self):
+        session = mock.MagicMock()
+        self.step.attributes = {'condor_job_statuses': [self.step.STATUS_COMPLETE]}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
+
+        self.assertEqual(
+            {'_legacy_0': self.step.STATUS_COMPLETE, NODE: self.step.STATUS_FAILED},
+            self.step.get_attribute('condor_job_statuses'),
+        )
+
+    def test_set_step_status_resolves_node_name_when_not_given(self):
+        session = mock.MagicMock()
+        self.step.attributes = {'condor_job_statuses': {}}
+        bind_locking_query(session, self.step)
+
+        with mock.patch.object(helpers, 'dag_node_name', return_value='resolved_node'):
+            helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE)
+
+        self.assertEqual(
+            {'resolved_node': self.step.STATUS_COMPLETE},
+            self.step.get_attribute('condor_job_statuses'),
+        )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
     def test_set_step_status_recovers_from_operational_error(self, mock_sessionmaker):
-        # First session raises on refresh (simulating a dead connection).
         bad_session = mock.MagicMock()
-        bad_session.refresh.side_effect = OperationalError('SELECT 1', {}, Exception('SSL closed'))
+        bind_locking_query(bad_session, self.step).one.side_effect = OperationalError(
+            'SELECT 1', {}, Exception('SSL closed')
+        )
 
-        # Fresh session built via sessionmaker() succeeds.
         fresh_session = mock.MagicMock()
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        step = ResourceWorkflowStep(name='n', help='h', order=1)
-        step.attributes = {'condor_job_statuses': [step.STATUS_PENDING]}
-        fresh_session.query.return_value.get.return_value = step
+        self.step.attributes = {'condor_job_statuses': {}}
+        fresh_session.query.return_value.get.return_value = self.step
+        bind_locking_query(fresh_session, self.step)
 
-        helpers.set_step_status(bad_session, step, step.STATUS_COMPLETE)
+        helpers.set_step_status(bad_session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
 
         bad_session.invalidate.assert_called_once()
         mock_sessionmaker.assert_called_once_with(bind=bad_session.get_bind.return_value)
         fresh_session.commit.assert_called_once()
         fresh_session.close.assert_called_once()
-        self.assertEqual([step.STATUS_PENDING, step.STATUS_COMPLETE], step.get_attribute('condor_job_statuses'))
+        self.assertEqual(
+            {NODE: self.step.STATUS_COMPLETE},
+            self.step.get_attribute('condor_job_statuses'),
+        )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
     def test_set_step_status_recovers_from_pending_rollback(self, mock_sessionmaker):
         bad_session = mock.MagicMock()
-        bad_session.refresh.side_effect = PendingRollbackError('rollback required')
+        bind_locking_query(bad_session, self.step).one.side_effect = PendingRollbackError(
+            'rollback required'
+        )
 
         fresh_session = mock.MagicMock()
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        step = ResourceWorkflowStep(name='n', help='h', order=1)
-        step.attributes = {'condor_job_statuses': [step.STATUS_PENDING]}
-        fresh_session.query.return_value.get.return_value = step
+        self.step.attributes = {'condor_job_statuses': {}}
+        fresh_session.query.return_value.get.return_value = self.step
+        bind_locking_query(fresh_session, self.step)
 
-        helpers.set_step_status(bad_session, step, step.STATUS_FAILED)
+        helpers.set_step_status(bad_session, self.step, self.step.STATUS_FAILED, node_name=NODE)
 
         bad_session.invalidate.assert_called_once()
         fresh_session.commit.assert_called_once()
-        self.assertEqual([step.STATUS_PENDING, step.STATUS_FAILED], step.get_attribute('condor_job_statuses'))
+        self.assertEqual(
+            {NODE: self.step.STATUS_FAILED},
+            self.step.get_attribute('condor_job_statuses'),
+        )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
     def test_set_step_status_propagates_if_retry_also_fails(self, mock_sessionmaker):
         bad_session = mock.MagicMock()
-        bad_session.refresh.side_effect = OperationalError('q', {}, Exception('boom'))
+        bind_locking_query(bad_session, self.step).one.side_effect = OperationalError(
+            'q', {}, Exception('boom')
+        )
 
         fresh_session = mock.MagicMock()
-        fresh_session.refresh.side_effect = OperationalError('q', {}, Exception('still dead'))
+        bind_locking_query(fresh_session, self.step).one.side_effect = OperationalError(
+            'q', {}, Exception('still dead')
+        )
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        step = ResourceWorkflowStep(name='n', help='h', order=1)
-        step.attributes = {'condor_job_statuses': []}
-        fresh_session.query.return_value.get.return_value = step
+        self.step.attributes = {'condor_job_statuses': {}}
+        fresh_session.query.return_value.get.return_value = self.step
 
         with self.assertRaises(OperationalError):
-            helpers.set_step_status(bad_session, step, step.STATUS_COMPLETE)
+            helpers.set_step_status(bad_session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
 
         fresh_session.close.assert_called_once()
 
     def test_set_step_status_propagates_non_recoverable_error(self):
         session = mock.MagicMock()
-        session.refresh.side_effect = ValueError('not a connection error')
+        bind_locking_query(session, self.step).one.side_effect = ValueError(
+            'not a connection error'
+        )
 
-        step = ResourceWorkflowStep(name='n', help='h', order=1)
-        step.attributes = {'condor_job_statuses': []}
+        self.step.attributes = {'condor_job_statuses': {}}
 
         with self.assertRaises(ValueError):
-            helpers.set_step_status(session, step, step.STATUS_COMPLETE)
+            helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
 
         session.invalidate.assert_not_called()
+
+    def test_dag_node_name_from_job_ad(self):
+        with tempfile.NamedTemporaryFile('w', suffix='.ad', delete=False) as job_ad:
+            job_ad.write('DAGManJobId = 423\n')
+            job_ad.write('DAGNodeName = "{}"\n'.format(NODE))
+            path = job_ad.name
+
+        try:
+            with mock.patch.dict(os.environ, {'_CONDOR_JOB_AD': path}):
+                self.assertEqual(NODE, helpers.dag_node_name())
+        finally:
+            os.unlink(path)
+
+    def test_dag_node_name_without_job_ad_is_unique(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            name = helpers.dag_node_name()
+
+        self.assertTrue(name.startswith('unknown_'))
+        self.assertIn(str(os.getpid()), name)
+
+    def test_dag_node_name_unreadable_job_ad(self):
+        with mock.patch.dict(os.environ, {'_CONDOR_JOB_AD': '/nonexistent/job.ad'}):
+            name = helpers.dag_node_name()
+
+        self.assertTrue(name.startswith('unknown_'))
+
+    def test_dag_node_name_job_ad_without_node_name(self):
+        with tempfile.NamedTemporaryFile('w', suffix='.ad', delete=False) as job_ad:
+            job_ad.write('ClusterId = 12\n')
+            path = job_ad.name
+
+        try:
+            with mock.patch.dict(os.environ, {'_CONDOR_JOB_AD': path}):
+                self.assertTrue(helpers.dag_node_name().startswith('unknown_'))
+        finally:
+            os.unlink(path)
+
+    def test_get_step_statuses_from_dict(self):
+        self.step.attributes = {'condor_job_statuses': {'a': 'Complete', 'b': 'Failed'}}
+
+        self.assertCountEqual(['Complete', 'Failed'], helpers.get_step_statuses(self.step))
+
+    def test_get_step_statuses_from_legacy_list(self):
+        self.step.attributes = {'condor_job_statuses': ['Complete', 'Failed']}
+
+        self.assertCountEqual(['Complete', 'Failed'], helpers.get_step_statuses(self.step))
+
+    def test_get_step_statuses_when_unset(self):
+        self.step.attributes = {}
+
+        self.assertEqual([], helpers.get_step_statuses(self.step))
 
     @mock.patch('argparse._sys')
     def test_parse_workflow_step_args(self, mock_sys):

--- a/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
@@ -10,12 +10,17 @@ from unittest import mock
 import os
 import tempfile
 import unittest
+from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError, PendingRollbackError
+from sqlalchemy.orm import sessionmaker
 from tethysext.atcore.services.resource_workflows import helpers
-from tethysext.atcore.models.app_users import ResourceWorkflowStep
+from tethysext.atcore.models.app_users import ResourceWorkflow, ResourceWorkflowStep, initialize_app_users_db
+from tethysext.atcore.tests import TEST_DB_URL
 from argparse import Namespace
 
 NODE = 'original_scenario_2yr'
+STATUSES = helpers.CONDOR_JOB_STATUSES_BY_NODE_KEY
+MIRROR = helpers.CONDOR_JOB_STATUSES_KEY
 
 
 def bind_locking_query(session, step):
@@ -31,26 +36,27 @@ class HelpersTests(unittest.TestCase):
 
     def setUp(self):
         self.step = ResourceWorkflowStep(name='name1', help='help1', order=1)
+        helpers.dag_node_name.cache_clear()
 
     def tearDown(self):
         pass
 
     def test_set_step_status(self):
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         bind_locking_query(session, self.step)
 
         helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
 
         self.assertEqual(
             {NODE: self.step.STATUS_COMPLETE},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
         session.commit.assert_called_once()
 
     def test_set_step_status_locks_the_row(self):
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         bind_locking_query(session, self.step)
 
         helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
@@ -60,20 +66,20 @@ class HelpersTests(unittest.TestCase):
 
     def test_set_step_status_keeps_other_nodes(self):
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': {'other_node': self.step.STATUS_COMPLETE}}
+        self.step.attributes = {STATUSES: {'other_node': self.step.STATUS_COMPLETE}}
         bind_locking_query(session, self.step)
 
         helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
 
         self.assertEqual(
             {'other_node': self.step.STATUS_COMPLETE, NODE: self.step.STATUS_FAILED},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
 
     def test_set_step_status_retry_overwrites_previous_status(self):
         """A node that fails and then succeeds must not leave the failure behind."""
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         bind_locking_query(session, self.step)
 
         helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
@@ -81,25 +87,25 @@ class HelpersTests(unittest.TestCase):
 
         self.assertEqual(
             {NODE: self.step.STATUS_COMPLETE},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
         self.assertNotIn(self.step.STATUS_FAILED, helpers.get_step_statuses(self.step))
 
     def test_set_step_status_migrates_legacy_list(self):
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': [self.step.STATUS_COMPLETE]}
+        self.step.attributes = {MIRROR: [self.step.STATUS_COMPLETE]}
         bind_locking_query(session, self.step)
 
         helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
 
         self.assertEqual(
             {'_legacy_0': self.step.STATUS_COMPLETE, NODE: self.step.STATUS_FAILED},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
 
     def test_set_step_status_resolves_node_name_when_not_given(self):
         session = mock.MagicMock()
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         bind_locking_query(session, self.step)
 
         with mock.patch.object(helpers, 'dag_node_name', return_value='resolved_node'):
@@ -107,7 +113,7 @@ class HelpersTests(unittest.TestCase):
 
         self.assertEqual(
             {'resolved_node': self.step.STATUS_COMPLETE},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
@@ -120,7 +126,7 @@ class HelpersTests(unittest.TestCase):
         fresh_session = mock.MagicMock()
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         fresh_session.query.return_value.get.return_value = self.step
         bind_locking_query(fresh_session, self.step)
 
@@ -132,7 +138,7 @@ class HelpersTests(unittest.TestCase):
         fresh_session.close.assert_called_once()
         self.assertEqual(
             {NODE: self.step.STATUS_COMPLETE},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
@@ -145,7 +151,7 @@ class HelpersTests(unittest.TestCase):
         fresh_session = mock.MagicMock()
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         fresh_session.query.return_value.get.return_value = self.step
         bind_locking_query(fresh_session, self.step)
 
@@ -155,7 +161,7 @@ class HelpersTests(unittest.TestCase):
         fresh_session.commit.assert_called_once()
         self.assertEqual(
             {NODE: self.step.STATUS_FAILED},
-            self.step.get_attribute('condor_job_statuses'),
+            self.step.get_attribute(STATUSES),
         )
 
     @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
@@ -171,7 +177,7 @@ class HelpersTests(unittest.TestCase):
         )
         mock_sessionmaker.return_value.return_value = fresh_session
 
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
         fresh_session.query.return_value.get.return_value = self.step
 
         with self.assertRaises(OperationalError):
@@ -185,7 +191,7 @@ class HelpersTests(unittest.TestCase):
             'not a connection error'
         )
 
-        self.step.attributes = {'condor_job_statuses': {}}
+        self.step.attributes = {STATUSES: {}}
 
         with self.assertRaises(ValueError):
             helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
@@ -229,12 +235,12 @@ class HelpersTests(unittest.TestCase):
             os.unlink(path)
 
     def test_get_step_statuses_from_dict(self):
-        self.step.attributes = {'condor_job_statuses': {'a': 'Complete', 'b': 'Failed'}}
+        self.step.attributes = {STATUSES: {'a': 'Complete', 'b': 'Failed'}}
 
         self.assertCountEqual(['Complete', 'Failed'], helpers.get_step_statuses(self.step))
 
     def test_get_step_statuses_from_legacy_list(self):
-        self.step.attributes = {'condor_job_statuses': ['Complete', 'Failed']}
+        self.step.attributes = {MIRROR: ['Complete', 'Failed']}
 
         self.assertCountEqual(['Complete', 'Failed'], helpers.get_step_statuses(self.step))
 
@@ -242,6 +248,192 @@ class HelpersTests(unittest.TestCase):
         self.step.attributes = {}
 
         self.assertEqual([], helpers.get_step_statuses(self.step))
+
+    def test_get_step_statuses_prefers_per_node_over_mirror(self):
+        """The mirror is written for rolled-back code; the per-node store is authoritative."""
+        self.step.attributes = {STATUSES: {'a': 'Complete'}, MIRROR: ['Stale']}
+
+        self.assertEqual(['Complete'], helpers.get_step_statuses(self.step))
+
+    def test_get_step_statuses_from_pre_release_dict_under_old_key(self):
+        """A build of this change that shipped before the mirror existed wrote a dict here."""
+        self.step.attributes = {MIRROR: {'a': 'Complete', 'b': 'Failed'}}
+
+        self.assertCountEqual(['Complete', 'Failed'], helpers.get_step_statuses(self.step))
+
+    def test_get_step_statuses_ignores_a_scalar(self):
+        """list('Failed') would yield characters, which would break the FAILED membership test."""
+        self.step.attributes = {MIRROR: 'Failed'}
+
+        self.assertEqual([], helpers.get_step_statuses(self.step))
+
+    def test_set_step_status_writes_the_legacy_mirror(self):
+        """Code rolled back to before the per-node store must still find a list here."""
+        session = mock.MagicMock()
+        self.step.attributes = {STATUSES: {'other_node': self.step.STATUS_COMPLETE}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_FAILED, node_name=NODE)
+
+        mirror = self.step.get_attribute(MIRROR)
+        self.assertIsInstance(mirror, list)
+        self.assertCountEqual([self.step.STATUS_COMPLETE, self.step.STATUS_FAILED], mirror)
+
+    def test_set_step_status_bounds_the_lock_wait_on_postgres(self):
+        session = mock.MagicMock()
+        session.get_bind.return_value.dialect.name = 'postgresql'
+        self.step.attributes = {STATUSES: {}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        statements = [str(call.args[0]) for call in session.execute.call_args_list if call.args]
+        self.assertTrue(
+            any('lock_timeout' in statement for statement in statements),
+            'expected a lock_timeout to be set before taking the row lock, got {}'.format(statements),
+        )
+
+    def test_set_step_status_skips_lock_timeout_on_other_backends(self):
+        """SET LOCAL lock_timeout is Postgres syntax; do not send it to another backend."""
+        session = mock.MagicMock()
+        session.get_bind.return_value.dialect.name = 'sqlite'
+        self.step.attributes = {STATUSES: {}}
+        bind_locking_query(session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        session.execute.assert_not_called()
+
+    def test_dag_node_name_is_stable_within_the_process(self):
+        """A job reports more than once; the fallback embeds a timestamp, so it must be cached."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            first = helpers.dag_node_name()
+            second = helpers.dag_node_name()
+
+        self.assertEqual(first, second)
+
+    def test_initialize_step_statuses_clears_both_shapes(self):
+        self.step.attributes = {STATUSES: {'a': 'Failed'}, MIRROR: ['Failed']}
+
+        helpers.initialize_step_statuses(self.step)
+
+        self.assertEqual({}, self.step.get_attribute(STATUSES))
+        self.assertEqual([], self.step.get_attribute(MIRROR))
+
+
+class SetStepStatusConcurrencyTests(unittest.TestCase):
+    """
+    Exercises the row lock against a real database.
+
+    The mocked tests above can only show that with_for_update() was called. Whether it
+    actually serializes two writers is a property of the database, so it needs real
+    connections: the shared-connection fixture used elsewhere in this suite runs every
+    test inside one transaction, which cannot demonstrate two transactions contending.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(TEST_DB_URL, connect_args={'connect_timeout': 5})
+        try:
+            cls.engine.connect().close()
+        except OperationalError as e:
+            raise unittest.SkipTest('test database at {} is unreachable: {}'.format(TEST_DB_URL, e))
+        initialize_app_users_db(cls.engine)
+        cls.Session = sessionmaker(bind=cls.engine)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.dispose()
+
+    def setUp(self):
+        helpers.dag_node_name.cache_clear()
+        self.session = self.Session()
+        self.workflow = ResourceWorkflow(name='concurrency_test')
+        self.step = ResourceWorkflowStep(name='concurrency_step', help='h', order=1)
+        self.step.attributes = {STATUSES: {}}
+        self.workflow.steps = [self.step]
+        self.session.add(self.workflow)
+        self.session.commit()
+        self.step_id = self.step.id
+
+    def tearDown(self):
+        self.session.rollback()
+        self.session.delete(self.session.query(ResourceWorkflow).get(self.workflow.id))
+        self.session.commit()
+        self.session.close()
+
+    def _fresh_step(self, session):
+        return session.query(ResourceWorkflowStep).get(self.step_id)
+
+    def test_concurrent_writers_do_not_lose_a_status(self):
+        """The bug this guards: a lost FAILED makes a failed workflow report success."""
+        session_a = self.Session()
+        session_b = self.Session()
+        try:
+            helpers.set_step_status(session_a, self._fresh_step(session_a), 'Failed', node_name='node_a')
+            helpers.set_step_status(session_b, self._fresh_step(session_b), 'Complete', node_name='node_b')
+        finally:
+            session_a.close()
+            session_b.close()
+
+        self.session.expire_all()
+        statuses = helpers.get_step_statuses(self._fresh_step(self.session))
+        self.assertCountEqual(['Failed', 'Complete'], statuses)
+
+    def test_second_writer_blocks_while_the_row_is_locked(self):
+        """Proves the lock is real: a held row lock must stop another writer, not be ignored."""
+        holder = self.Session()
+        contender = self.Session()
+        try:
+            # Take and hold the same lock _record_status takes, without committing.
+            holder.query(ResourceWorkflowStep).populate_existing().with_for_update() \
+                .filter_by(id=self.step_id).one()
+
+            with mock.patch.object(helpers, 'STATUS_LOCK_TIMEOUT_MS', 500):
+                # Both the first attempt and set_step_status's one retry must hit the lock.
+                with self.assertRaises(OperationalError):
+                    helpers.set_step_status(
+                        contender, self._fresh_step(contender), 'Complete', node_name='blocked_node',
+                    )
+        finally:
+            holder.rollback()
+            holder.close()
+            contender.rollback()
+            contender.close()
+
+        # Nothing from the blocked writer was persisted.
+        self.session.expire_all()
+        self.assertEqual([], helpers.get_step_statuses(self._fresh_step(self.session)))
+
+    def test_writer_succeeds_once_the_lock_is_released(self):
+        holder = self.Session()
+        holder.query(ResourceWorkflowStep).populate_existing().with_for_update() \
+            .filter_by(id=self.step_id).one()
+        holder.rollback()
+        holder.close()
+
+        session_b = self.Session()
+        try:
+            helpers.set_step_status(session_b, self._fresh_step(session_b), 'Complete', node_name='node_b')
+        finally:
+            session_b.close()
+
+        self.session.expire_all()
+        self.assertEqual(['Complete'], helpers.get_step_statuses(self._fresh_step(self.session)))
+
+    def test_legacy_mirror_is_persisted_for_rolled_back_code(self):
+        session_a = self.Session()
+        try:
+            helpers.set_step_status(session_a, self._fresh_step(session_a), 'Failed', node_name='node_a')
+        finally:
+            session_a.close()
+
+        self.session.expire_all()
+        mirror = self._fresh_step(self.session).get_attribute(MIRROR)
+        self.assertEqual(['Failed'], mirror)
+
+
+class HelpersArgParseTests(unittest.TestCase):
 
     @mock.patch('argparse._sys')
     def test_parse_workflow_step_args(self, mock_sys):

--- a/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
+++ b/tethysext/atcore/tests/integrated_tests/services/resource_workflows/helpers_tests.py
@@ -312,6 +312,51 @@ class HelpersTests(unittest.TestCase):
 
         self.assertEqual(first, second)
 
+    def test_set_step_status_retries_a_lock_timeout_without_discarding_the_connection(self):
+        """Contention is not a broken connection; invalidate() would throw away a good one."""
+        session = mock.MagicMock()
+        lock_timeout = OperationalError('SELECT 1', {}, Exception('canceled'))
+        lock_timeout.orig.pgcode = helpers.LOCK_NOT_AVAILABLE
+
+        self.step.attributes = {STATUSES: {}}
+        locking = bind_locking_query(session, self.step)
+        locking.one.side_effect = [lock_timeout, self.step]
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        session.invalidate.assert_not_called()
+        session.rollback.assert_called_once()
+        self.assertEqual({NODE: self.step.STATUS_COMPLETE}, self.step.get_attribute(STATUSES))
+
+    @mock.patch('tethysext.atcore.services.resource_workflows.helpers.sessionmaker')
+    def test_set_step_status_still_invalidates_a_dead_connection(self, mock_sessionmaker):
+        """A non-lock-timeout OperationalError is a dead connection and must be evicted."""
+        session = mock.MagicMock()
+        dead = OperationalError('SELECT 1', {}, Exception('SSL closed'))
+        dead.orig.pgcode = '08006'
+        bind_locking_query(session, self.step).one.side_effect = dead
+
+        fresh_session = mock.MagicMock()
+        mock_sessionmaker.return_value.return_value = fresh_session
+        self.step.attributes = {STATUSES: {}}
+        fresh_session.query.return_value.get.return_value = self.step
+        bind_locking_query(fresh_session, self.step)
+
+        helpers.set_step_status(session, self.step, self.step.STATUS_COMPLETE, node_name=NODE)
+
+        session.invalidate.assert_called_once()
+        fresh_session.commit.assert_called_once()
+
+    def test_is_lock_timeout(self):
+        lock_timeout = OperationalError('q', {}, Exception('canceled'))
+        lock_timeout.orig.pgcode = helpers.LOCK_NOT_AVAILABLE
+        other = OperationalError('q', {}, Exception('boom'))
+        other.orig.pgcode = '08006'
+
+        self.assertTrue(helpers._is_lock_timeout(lock_timeout))
+        self.assertFalse(helpers._is_lock_timeout(other))
+        self.assertFalse(helpers._is_lock_timeout(PendingRollbackError('rollback required')))
+
     def test_initialize_step_statuses_clears_both_shapes(self):
         self.step.attributes = {STATUSES: {'a': 'Failed'}, MIRROR: ['Failed']}
 


### PR DESCRIPTION
## The problem

A step's sub-job statuses are kept in a flat list on the step. Each node appends its own outcome as it finishes:

```python
step_statuses = step.get_attribute('condor_job_statuses')
step_statuses.append(status)
step.set_attribute('condor_job_statuses', step_statuses)
```

and `finalize` marks the step failed if `FAILED` appears anywhere in it. Two problems follow from that shape.

### Concurrent nodes lose each other's writes

The statuses live under one key of the step's attributes, and `set_attribute` re-serializes the whole attributes document — so recording a status is a read-modify-write of a single column, with no lock. `_attributes` is `Column(String)` holding JSON, so there is no atomic per-key update available.

Two nodes finishing at the same time interleave like this:

```
node A                              node B
refresh  -> ["COMPLETE"]
                                    refresh  -> ["COMPLETE"]
append("FAILED")
                                    append("COMPLETE")
UPDATE ... ["COMPLETE","FAILED"]
COMMIT
                                    UPDATE ... ["COMPLETE","COMPLETE"]
                                    COMMIT      <- overwrites A entirely
```

The failure is gone and the step reports **success for a workflow that failed**. `session.refresh()` narrows the window but issues a plain `SELECT`, so it does not prevent this.

A fan-out step submits its nodes together and they tend to finish together, so this is the expected case rather than an unlikely one. Because the whole attributes document is rewritten, a concurrent write to any *other* attribute is lost too.

### A retried node leaves its earlier status behind

A node that fails and then succeeds appends both, leaving `['FAILED', 'COMPLETE']`. `finalize` sees the `FAILED` and marks the whole step failed even though everything ultimately succeeded.

This makes the current shape unsafe for `max_retries` / `on_exit_remove`, so it blocks adding retry directives at all — a single transient eviction would turn a successful run into a reported failure.

## The change

Key the statuses by node name and overwrite rather than append, and lock the step row for the read-modify-write:

```python
locked_step = (
    session.query(type(step))
    .populate_existing()
    .with_for_update()
    .filter_by(id=step.id)
    .one()
)
statuses[node_name] = status
```

A retry now replaces its own entry, and concurrent nodes serialize instead of clobbering each other. The lock is held only for this small write, and `ResourceWorkflowStep` uses single-table inheritance, so this is a single-table `SELECT ... FOR UPDATE`.

## How a node knows its own name

From its job ad, with no new arguments. DAGMan adds `DAGNodeName` to every node it submits, and HTCondor exposes the job ad to the running job through the `_CONDOR_JOB_AD` environment variable.

This matters because `job_args` are positional and apps append their own arguments after them (`self.job_args + existing_job_args`), with `parse_workflow_step_args()` relying on the exact ordering — so inserting a positional argument would be a breaking change for every app. Reading the job ad needs nothing from the apps at all.

When the node name cannot be determined the fallback is process-unique. A constant fallback would make every node overwrite the same entry, which would be worse than the bug being fixed.

## Compatibility

- `get_step_statuses()` reads either shape, so `finalize` works against both.
- A step that was already running when this is deployed keeps its statuses under generated `_legacy_N` keys rather than losing them. Worth keeping that branch for at least one release.
- New steps are initialized to `{}` instead of `[]`.

## Testing

19 tests in `helpers_tests.py`, including the retry-overwrite case, the legacy-list migration, that the row is locked, the node-name resolution and each of its fallbacks, and the existing dead-connection recovery paths (updated, since the implementation no longer calls `session.refresh`).

Not covered here: a true concurrency test needs multiple real sessions against Postgres, and would be worth adding to confirm the `FOR UPDATE` behaves under the fan-out shape. Given a deadlock was recently fixed in this same column, that is worth measuring rather than assuming.